### PR TITLE
fix: Windows portability for magic command, installer, and updater

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Force LF line endings in the working tree on every platform.
+#
+# The boilerplate updater (cli/lib/updater-core.ts) byte-compares local files
+# against LF-normalized git blobs, and several CLI/lint scripts split on '\n'.
+# On a Windows checkout with core.autocrlf=true those files would otherwise be
+# CRLF and misbehave: the updater flags every managed file as locally modified
+# and skills:registry --check flakes. Pinning eol=lf keeps Windows behaviour
+# identical to macOS/Linux.
+* text=auto eol=lf
+
+# Binaries: never normalize.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.pdf   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -268,6 +268,14 @@ function shellHookLine(): { line: string, rc: string } {
   if (shell.endsWith('fish')) {
     return { line: 'direnv hook fish | source', rc: '~/.config/fish/config.fish' };
   }
+  if (shell.endsWith('bash')) {
+    return { line: 'eval "$(direnv hook bash)"', rc: '~/.bashrc' };
+  }
+  // No POSIX $SHELL (typical on native Windows PowerShell) — advise the pwsh hook
+  // instead of mis-instructing the user to edit ~/.bashrc.
+  if (process.platform === 'win32') {
+    return { line: 'Invoke-Expression "$(direnv hook pwsh)"', rc: '$PROFILE' };
+  }
   return { line: 'eval "$(direnv hook bash)"', rc: '~/.bashrc' };
 }
 

--- a/cli/lib/updater-core.ts
+++ b/cli/lib/updater-core.ts
@@ -1443,7 +1443,11 @@ function collectComponentRelPaths(component: Component, templateDir: string): st
       walk(srcPath);
     }
     else {
-      out.push(componentPath);
+      // Normalize separators so file-list / single-file components produce the same
+      // forward-slash relPaths as the directory-walk branch above. Otherwise path.join's
+      // backslashes on Windows break the git pathspecs used to bootstrap these files,
+      // and they are silently skipped.
+      out.push(componentPath.replace(/\\/g, '/'));
     }
   }
   return out;

--- a/cli/update-boilerplate.ts
+++ b/cli/update-boilerplate.ts
@@ -378,7 +378,7 @@ function buildSink(): ReportSink {
         if (abortOnCancel<boolean>(openExternal)) {
           const tmp = path.join(os.tmpdir(), `upex-diff-${process.pid}-${Date.now()}.txt`);
           fs.writeFileSync(tmp, plain);
-          const editor = process.env.EDITOR || process.env.VISUAL || 'less';
+          const editor = process.env.EDITOR || process.env.VISUAL || (process.platform === 'win32' ? 'notepad' : 'less');
           try { spawnSync(editor, [tmp], { stdio: 'inherit' }); }
           catch { tui.log.warn(`No se pudo abrir ${editor}. Contenido en: ${tmp}`); return; }
           finally {

--- a/packages/create-agentic-qa/src/download.ts
+++ b/packages/create-agentic-qa/src/download.ts
@@ -68,9 +68,21 @@ export async function downloadTemplate(opts: {
 
   // 4) Extract, stripping top-level GitHub-wrapper dir
   log.info(`Extracting into ${targetDir}`);
+  const isWin = process.platform === 'win32';
+  // Windows: GNU tar reads `C:\path` as host:path (rsync-style remote); --force-local disables that.
+  // Forward slashes avoid backslashes being interpreted as escape sequences after --force-local.
+  const tarSrc = isWin ? tarballPath.replace(/\\/g, '/') : tarballPath;
+  const tarDst = isWin ? targetDir.replace(/\\/g, '/') : targetDir;
   const extract = spawnSync(
     'tar',
-    ['-xzf', tarballPath, '-C', targetDir, '--strip-components=1'],
+    [
+      ...(isWin ? ['--force-local'] : []),
+      '-xzf',
+      tarSrc,
+      '-C',
+      tarDst,
+      '--strip-components=1',
+    ],
     { stdio: ['ignore', 'inherit', 'inherit'] },
   );
   // Cleanup tarball regardless of extract outcome

--- a/scripts/lint-skills.ts
+++ b/scripts/lint-skills.ts
@@ -719,9 +719,14 @@ function walkSkillMarkdown(dir: string, files: string[] = []): string[] {
 
 /** Map a SKILLS_DIR-rooted file path to its owning skill slug, or null. */
 function skillSlugForFile(file: string): string | null {
-  const prefix = `${SKILLS_DIR}/`;
-  if (!file.startsWith(prefix)) { return null; }
-  const rest = file.slice(prefix.length);
+  // Normalize separators before comparing. `SKILLS_DIR` and `file` are built with
+  // path.join (backslashes on Windows), but the prefix is forward-slash-suffixed.
+  // Without normalization every startsWith() fails on Windows, so no file maps to a
+  // skill slug and every tool-owner skill loses its SKILL-LITERAL-TOOL/CFID exemption.
+  const normFile = file.replace(/\\/g, '/');
+  const prefix = `${SKILLS_DIR.replace(/\\/g, '/')}/`;
+  if (!normFile.startsWith(prefix)) { return null; }
+  const rest = normFile.slice(prefix.length);
   const slash = rest.indexOf('/');
   return slash === -1 ? rest : rest.slice(0, slash);
 }

--- a/scripts/sync-jira-issues.ts
+++ b/scripts/sync-jira-issues.ts
@@ -70,7 +70,7 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 
 // ============================================================================
@@ -967,7 +967,9 @@ function writeIfNotProtected(
   content: string,
   dryRun: boolean,
 ): { written: boolean, status: 'created' | 'updated' | 'skipped' } {
-  const filename = filePath.split('/').pop() || '';
+  // basename (not split('/')) so protected-file detection works on Windows,
+  // where filePath is built with path.join and uses backslash separators.
+  const filename = basename(filePath);
 
   if (isProtectedFile(filename)) {
     return { written: false, status: 'skipped' };
@@ -1727,7 +1729,7 @@ async function syncEpic(
 
   if (!options.json) {
     log.line('');
-    log.info(`Syncing ${epicFolder.split('/').pop()}`);
+    log.info(`Syncing ${basename(epicFolder)}`);
   }
 
   // Materialize epic-level planning field files (feature impl plan, feature test plan)


### PR DESCRIPTION
## Summary

Windows users could not complete setup — most visibly, `bunx create-agentic-qa@latest --here` died during extraction in PowerShell/cmd (it only worked in Git Bash). This branch closes that and the rest of the cross-platform gaps in the magic command, installer, boilerplate updater, and setup scripts. Root cause is JS-level path handling (`path.sep` is `\` in every Windows terminal) plus CRLF. All changes are no-ops on macOS/Linux.

## Changes

- **create-agentic-qa**: add `--force-local` and forward-slash the temp/target paths in the `tar` extraction so the magic command works in PowerShell/cmd, not just Git Bash (GNU tar was reading `C:\...` as an rsync host:path). Mirrors the fix already in create-agentic-dev.
- **lint-skills**: normalize path separators in `skillSlugForFile` so tool-owner skill exemptions (`acli`, `xray-cli`) resolve on Windows (was failing `bun run repo:check` during setup).
- **jira-sync**: use `path.basename` for protected-file detection in `writeIfNotProtected` — Windows backslash paths bypassed the guard and overwrote hand-edited files.
- **updater**: normalize component bootstrap paths to forward slashes so git pathspecs match on Windows (files were silently skipped).
- **.gitattributes** (new): pin `* text=auto eol=lf` so the updater byte-compare and lint scripts behave identically on Windows checkouts (`core.autocrlf=true`).
- **cli polish**: doctor advises the pwsh `direnv` hook when `$SHELL` is unset (native PowerShell); external-diff viewer defaults to `notepad` on win32.

## Test plan

- `bun run repo:check` green on macOS (format + eslint + types + vars + skills + registry).
- Path-normalization edits are no-ops on macOS/Linux; `.gitattributes` produced 0 files on `git add --renormalize .` (repo already LF).
- ⚠️ Pending validation on real Windows (PowerShell/cmd): `bunx create-agentic-qa@latest --here` and `bun run setup` end-to-end.

## Risk

Low. No behavior change on macOS/Linux. Windows-only paths are guarded by `process.platform === 'win32'` or are separator normalization that is inert on POSIX paths.
