### PR TITLE
fix(updater): sync .gitattributes downstream + dedup .prettierignore handling

### DIFF
--- a/cli/update-boilerplate.ts
+++ b/cli/update-boilerplate.ts
@@ -23,7 +23,7 @@ const TEMPLATE_REPO = 'upex-galaxy/agentic-qa-boilerplate';
 const TEMP_DIR = path.join(os.tmpdir(), 'kata-boilerplate-update');
 const VERSION_FILE = '.template/boilerplate.lock.json';
 
-const TOOLING_FILES = ['.editorconfig', '.prettierrc', '.prettierignore'];
+const TOOLING_FILES = ['.editorconfig', '.prettierrc', '.prettierignore', '.gitattributes'];
 const AGENTS_DOCS_FILES = ['README.md'];
 const CLAUDE_CONFIG_FILES = ['settings.json'];
 

--- a/cli/update-boilerplate.ts
+++ b/cli/update-boilerplate.ts
@@ -23,7 +23,7 @@ const TEMPLATE_REPO = 'upex-galaxy/agentic-qa-boilerplate';
 const TEMP_DIR = path.join(os.tmpdir(), 'kata-boilerplate-update');
 const VERSION_FILE = '.template/boilerplate.lock.json';
 
-const TOOLING_FILES = ['.editorconfig', '.prettierrc', '.prettierignore', '.gitattributes'];
+const TOOLING_FILES = ['.editorconfig', '.prettierrc', '.gitattributes'];
 const AGENTS_DOCS_FILES = ['README.md'];
 const CLAUDE_CONFIG_FILES = ['settings.json'];
 


### PR DESCRIPTION
## Summary

Two updater-registry fixes so the new `.gitattributes` reaches existing projects and `.prettierignore` is handled consistently.

## Changes

- Add `.gitattributes` to `TOOLING_FILES` so existing projects receive it via `bun up` (previously it shipped only to fresh projects through the create-agentic scaffolder, since it belonged to no update component).
- Remove `.prettierignore` from `TOOLING_FILES`: it was double-handled — whole-file sync (tooling, Phase 4) **and** sentinel append (ignoreFiles, Phase 4.5). It is an ignore-style file users extend, so the append-only path is correct; it stays in `ignoreFiles`.

## Test plan

- `bun run repo:check` green on macOS (both repos).
- No behavior change on macOS/Linux.

## Risk

Low — registry-only change. New file propagates as `new-upstream` (written fresh); `.prettierignore` keeps its append-only sync.
