### PR TITLE
docs(sdet): scope-aware trunk naming + -e2e -> -suite suffix

### DIFF
--- a/.claude/skills/agentic-qa-core/references/session-management.md
+++ b/.claude/skills/agentic-qa-core/references/session-management.md
@@ -197,7 +197,7 @@ For a chained test-automation suite running the `sdet` strategy (`.claude/skills
 Each ledger line is one append-only snapshot at a phase boundary or branch action. Recommended shape:
 
 ```
-- git: trunk <test/<module>-e2e>@<short-sha> | merged <test/{KEY}> --no-ff | pending: <KEY..KEY> | sync-gate: <no|done> | final-PR: <none|#NN>
+- git: trunk <test/<module>-suite>@<short-sha> | merged <test/{KEY}> --no-ff | pending: <KEY..KEY> | sync-gate: <no|done> | final-PR: <none|#NN>
 ```
 
 Because the field is append-only like every other line, the **latest** `git:` entry in the tail is the current truth; earlier ones are history. Never rewrite a prior `git:` line — append a new phase entry. This is the resume signal for "how did the SDET branches end up?" that the strategy depends on (reinforces it even if a later session forgets the flow).

--- a/.claude/skills/git-flow-master/SKILL.md
+++ b/.claude/skills/git-flow-master/SKILL.md
@@ -98,7 +98,7 @@ The skill supports eight strategies (see `references/branching-strategies.md` fo
 | `gitflow`          | Vincent Driessen's classic. `main` (releases) + `develop` (integration) + `feature/*` + `release/*` + `hotfix/*`. Heavyweight; mostly legacy.    |
 | `github-flow`      | `main` always deployable. `feature/*` branches → PR → merge → deploy. No staging/develop branch.                                                 |
 | `gitlab-flow`      | GitHub Flow + environment branches (`pre-production`, `production`) to model deployment promotion.                                               |
-| `sdet`             | SDET Gitflow. `main` (confirmed tests) + ephemeral per-suite integration trunk `test/<module>-e2e`. Test tickets chain through the trunk (`--no-ff`); one final PR → `main`. For chained test-automation suites. Opt-in; see `references/sdet-integration-trunk.md`. |
+| `sdet`             | SDET Gitflow. `main` (confirmed tests) + ephemeral per-suite integration trunk `test/<module>-suite`. Test tickets chain through the trunk (`--no-ff`); one final PR → `main`. For chained test-automation suites. Opt-in; see `references/sdet-integration-trunk.md`. |
 
 ### Detection algorithm
 
@@ -109,7 +109,7 @@ Apply in order; stop at the first definitive answer:
 3. **Two-branch heuristic** — exactly `main` (or `master`) + one of `{staging, dev, develop, integration}` exists upstream → `main-integration` (record the integration branch name).
 4. **Multi-branch heuristic** — `main` + integration + active `feature/*` or `release/*` branches in `git branch -a` → `enterprise`.
 5. **Project hints** — look for `.gitlab-ci.yml` (suggests `gitlab-flow`), `release/*` and `hotfix/*` long-lived branches (suggests `gitflow`).
-6. **Fallback** — ask the user. Show the options with one-line descriptions; mirror their language. Do NOT pick silently. On a test-automation repo (KATA / Playwright / `/test-automation`), surface `sdet` as the recommended option. `sdet` is opt-in only — never inferred silently from layout; a live `test/<module>-e2e` trunk with `test/{KEY}-*` PRs targeting it confirms an already-active `sdet` suite.
+6. **Fallback** — ask the user. Show the options with one-line descriptions; mirror their language. Do NOT pick silently. On a test-automation repo (KATA / Playwright / `/test-automation`), surface `sdet` as the recommended option. `sdet` is opt-in only — never inferred silently from layout; a live `test/<module>-suite` trunk with `test/{KEY}-*` PRs targeting it confirms an already-active `sdet` suite.
 
 ### Persist the decision
 
@@ -189,7 +189,7 @@ In a QA repo most work lands as `test/`, `fix/`, or `chore/` branches. Feature b
 - `main-integration`, `gitlab-flow` → branch off the integration branch (`staging` / `dev` / equivalent).
 - `enterprise` → branch off the integration branch unless it is a `hotfix/*`, which branches off `main`.
 - `gitflow` → `feature/*` branches off `develop`; `hotfix/*` off `main`; `release/*` off `develop`.
-- `sdet` → `test/{KEY}-*` ticket branches + Plus Branches (`docs/*`/`chore/*`/`fix/*`) branch off the **ephemeral integration trunk** `test/<module>-e2e`; the trunk itself is cut from `main` on demand when a suite begins. Never stack a ticket on the previous ticket branch. See `references/sdet-integration-trunk.md`.
+- `sdet` → `test/{KEY}-*` ticket branches + Plus Branches (`docs/*`/`chore/*`/`fix/*`) branch off the **ephemeral integration trunk** `test/<module>-suite`; the trunk itself is cut from `main` on demand when a suite begins. Never stack a ticket on the previous ticket branch. See `references/sdet-integration-trunk.md`.
 
 Always **propose** the name and ask for OK before `git checkout -b`. Never create silently.
 
@@ -255,7 +255,7 @@ Ask: _"You are about to push directly to the protected branch `{branch}` in a `{
 | `main-integration`, `gitlab-flow`         | integration branch (e.g. `staging`)                                                              |
 | `enterprise`                              | integration branch; `hotfix/*` → `main`                                                          |
 | `gitflow`                                 | `feature/*` → `develop`; `hotfix/*` → `main`; `release/*` → `main` (and back-merge to `develop`) |
-| `sdet`                                    | `test/{KEY}-*` ticket branches + Plus Branches → the integration trunk `test/<module>-e2e`; the single final suite PR → `main` (after the sync gate). See `references/sdet-integration-trunk.md`. |
+| `sdet`                                    | `test/{KEY}-*` ticket branches + Plus Branches → the integration trunk `test/<module>-suite`; the single final suite PR → `main` (after the sync gate). See `references/sdet-integration-trunk.md`. |
 
 The user can override with `--base X` in arguments. If overridden, surface it in the confirmation: _"PR will target `{base}` instead of the strategy default `{default}`."_
 

--- a/.claude/skills/git-flow-master/references/branching-strategies.md
+++ b/.claude/skills/git-flow-master/references/branching-strategies.md
@@ -237,20 +237,20 @@ Eight strategies are supported. Each one tells the skill where new branches star
 
 **SDET Gitflow — integration-trunk for chained test-automation suites.** Full runbook: `references/sdet-integration-trunk.md`.
 
-**Shape**: `main` (permanent — holds confirmed, regression-ready tests) + an **ephemeral per-suite integration trunk** named `test/<module>-e2e`. The trunk is the local surrogate-`main` for one test suite: it is created off `main` when the suite starts and deleted after the suite's final PR merges. Each ticket is a `test/{KEY}-{slug}` branch cut from the trunk, PR'd **into the trunk** (not `main`), and merged `--no-ff`. Adjacent non-test work rides **Plus Branches** (`docs/*`, `chore/*`, `fix/*`) that also PR into the trunk. One final reviewed PR promotes `trunk → main`.
+**Shape**: `main` (permanent — holds confirmed, regression-ready tests) + an **ephemeral per-suite integration trunk** named `test/<module>-suite`. The trunk is the local surrogate-`main` for one test suite: it is created off `main` when the suite starts and deleted after the suite's final PR merges. Each ticket is a `test/{KEY}-{slug}` branch cut from the trunk, PR'd **into the trunk** (not `main`), and merged `--no-ff`. Adjacent non-test work rides **Plus Branches** (`docs/*`, `chore/*`, `fix/*`) that also PR into the trunk. One final reviewed PR promotes `trunk → main`.
 
 **Best for**: test-automation repos where a single maintainer (or AI agent) automates multi-ticket suites (a whole module, or a chained ticket-driven scope from `/test-automation`). The defining problem it solves: avoid one giant unreviewable PR, avoid one tiny PR per ticket paying `main`'s ruleset tax, and keep the final diff clean.
 
 **Detection signals**:
 
 - `<!-- git-flow-master:strategy:sdet -->` marker in `CLAUDE.md` (primary — this strategy is opt-in, never silently auto-detected).
-- A long-lived-for-the-suite `test/<module>-e2e` trunk + multiple `test/{KEY}-*` ticket PRs targeting it (not `main`).
+- A long-lived-for-the-suite `test/<module>-suite` trunk + multiple `test/{KEY}-*` ticket PRs targeting it (not `main`).
 - A QA/test-automation boilerplate repo (KATA, Playwright, `/test-automation` skill present).
 
 **Source branch for new work**:
 
 - `test/{KEY}-{slug}` ticket branches → cut from the **integration trunk** (never from the previous ticket branch).
-- The trunk `test/<module>-e2e` itself → cut from `main` on demand when a suite begins (NOT at Strategy Setup time).
+- The trunk `test/<module>-suite` itself → cut from `main` on demand when a suite begins (NOT at Strategy Setup time).
 - Plus Branches (`docs/*`, `chore/*`, `fix/*`) → cut from the trunk, carry adjacent non-test work.
 
 **PR base**:
@@ -273,7 +273,7 @@ Eight strategies are supported. Each one tells the skill where new branches star
 <!-- git-flow-master:feature-merge:merge-commit -->
 ```
 
-`feature-merge` is fixed at `merge-commit` (`--no-ff`) — it is a defining property, not a questionnaire answer. `integration-branch` is NOT persisted (the trunk is ephemeral per-suite, named `test/<module>-e2e` at suite start). `promote-method` / `hotfix-policy` do not apply (no production deploy; `main` is the confirmed-tests branch).
+`feature-merge` is fixed at `merge-commit` (`--no-ff`) — it is a defining property, not a questionnaire answer. `integration-branch` is NOT persisted (the trunk is ephemeral per-suite, named `test/<module>-suite` at suite start). `promote-method` / `hotfix-policy` do not apply (no production deploy; `main` is the confirmed-tests branch).
 
 **Trade-offs**:
 
@@ -315,7 +315,7 @@ The combined detection runs in this order. Stop at the first definitive answer.
 Note on `sdet`: it is **opt-in only** — never inferred silently from layout. It is
 resolved from the marker (step 1) or chosen explicitly in the fallback (step 5). On a
 test-automation repo (KATA / Playwright / `/test-automation`), surface it as the
-recommended option in the fallback list. A live `test/<module>-e2e` trunk with
+recommended option in the fallback list. A live `test/<module>-suite` trunk with
 `test/{KEY}-*` PRs targeting it confirms an already-active `sdet` suite.
 ```
 
@@ -690,7 +690,7 @@ Hotfix flow:
 
 - **(a) Markers**: `strategy:sdet` + `feature-merge:merge-commit` (fixed). NO `integration-branch` marker (trunk is ephemeral per-suite). NO `promote-method` / `hotfix-policy` (no production deploy).
 - **(b) Invariant**: none. `main` holds confirmed tests, not a deployed app; there is no ancestor invariant.
-- **(c) Branch table**: `main` + the trunk pattern `test/<module>-e2e` + `test/{KEY}-*` ticket branches + Plus Branches (`docs/*`/`chore/*`/`fix/*`).
+- **(c) Branch table**: `main` + the trunk pattern `test/<module>-suite` + `test/{KEY}-*` ticket branches + Plus Branches (`docs/*`/`chore/*`/`fix/*`).
 - **(d)**: ticket/Plus → trunk is `--no-ff` (fixed); the sync gate + single final `trunk → main` PR replace any promotion/hotfix block. Point to `references/sdet-integration-trunk.md` for the per-ticket loop, CI-fallback clause, and sync gate.
 
 Example shape:
@@ -702,14 +702,14 @@ Example shape:
 <!-- git-flow-master:feature-merge:merge-commit -->
 
 This project uses the `sdet` (SDET Gitflow) flow. `main` holds confirmed, regression-ready
-tests. Each test suite runs on an ephemeral integration trunk `test/<module>-e2e` (created
+tests. Each test suite runs on an ephemeral integration trunk `test/<module>-suite` (created
 off `main`, deleted after the suite merges). Tickets chain through the trunk; one final
 reviewed PR promotes the suite to `main`. Full runbook: `.claude/skills/git-flow-master/references/sdet-integration-trunk.md`.
 
 | Branch              | Role                                                                  |
 | ------------------- | --------------------------------------------------------------------- |
 | main                | Confirmed tests. Only the final suite PR (reviewed, green CI) lands.   |
-| test/<module>-e2e   | Ephemeral per-suite integration trunk. Surrogate-main for the suite.  |
+| test/<module>-suite   | Ephemeral per-suite integration trunk. Surrogate-main for the suite.  |
 | test/{KEY}-{slug}   | Ticket branch. Cut from the trunk; PR → trunk; merged --no-ff.        |
 | docs/* chore/* fix/*| Plus Branches. Adjacent non-test work; PR → trunk like tickets.       |
 
@@ -719,12 +719,12 @@ Merge methods (decided, do not improvise):
 | trunk → main (final PR)     | Repo merge setting (prefer merge-commit)        |
 
 Per-suite flow:
-  git checkout -b test/<module>-e2e main && git push -u origin test/<module>-e2e   # start suite
+  git checkout -b test/<module>-suite main && git push -u origin test/<module>-suite   # start suite
   # per ticket: cut from trunk → local PASS on local AND staging → push → Sanity CI
   #             → PR into trunk → review → merge --no-ff → next ticket from updated trunk
-  git checkout test/<module>-e2e && git merge origin/main          # sync gate before final PR
+  git checkout test/<module>-suite && git merge origin/main          # sync gate before final PR
   # final PR trunk → main (only PR facing rulesets; genuinely green, no CI-fallback)
-  git push origin --delete test/<module>-e2e                       # after merge
+  git push origin --delete test/<module>-suite                       # after merge
 
 CI-fallback clause (trunk merges only, never the final PR): a Sanity-CI red that is purely
 infra/known-flake — proven by a local pass on BOTH local and staging AND the red existing

--- a/.claude/skills/git-flow-master/references/pr-templating.md
+++ b/.claude/skills/git-flow-master/references/pr-templating.md
@@ -84,7 +84,7 @@ Do not pad sections. Empty sections invite skim-reads.
 | `gitflow`          | `develop` for `feature/*`; `main` for `release/*` and `hotfix/*` | Release PRs back-merge to `develop` after merging to `main`.    |
 | `github-flow`      | `main`                                                           | Always.                                                         |
 | `gitlab-flow`      | `main`                                                           | Promotion MRs target `pre-production`, then `production`.       |
-| `sdet`             | integration trunk `test/<module>-e2e` for `test/{KEY}-*` + Plus Branches | The single final suite PR targets `main` (after the sync gate). Use the `pr-test-automation.md` body for the final PR. See `sdet-integration-trunk.md`. |
+| `sdet`             | integration trunk `test/<module>-suite` for `test/{KEY}-*` + Plus Branches | The single final suite PR targets `main` (after the sync gate). Use the `pr-test-automation.md` body for the final PR. See `sdet-integration-trunk.md`. |
 
 The user can override with `--base X` in arguments. When overridden, surface it in the confirmation:
 

--- a/.claude/skills/git-flow-master/references/sdet-integration-trunk.md
+++ b/.claude/skills/git-flow-master/references/sdet-integration-trunk.md
@@ -8,7 +8,7 @@ This file is the heavy runbook behind the `sdet` strategy (catalogue entry in `b
 
 ## TL;DR
 
-- One **integration trunk** acts as the local surrogate-`main` for the whole suite (e.g. `test/monthly-statement-e2e`). It is **ephemeral per suite**: created when the suite starts, deleted after the final PR merges.
+- One **integration trunk** acts as the local surrogate-`main` for the whole suite (e.g. `test/monthly-statement-suite`). It is **ephemeral per suite**: created when the suite starts, deleted after the final PR merges.
 - Each ticket is cut **from the trunk** (never stacked on the previous ticket branch), worked, validated locally on **both `local` and `staging`**, pushed, Sanity-CI'd, PR'd **into the trunk** (not `main`), reviewed, fixed, and merged with **`--no-ff`** (never squash).
 - The next ticket is cut from the **updated trunk** after each merge.
 - Adjacent non-test work (docs / tooling / fixes) is parked in **Plus Branches** inserted between tickets; they PR into the trunk like ticket branches.
@@ -16,6 +16,22 @@ This file is the heavy runbook behind the `sdet` strategy (catalogue entry in `b
 - A single, pre-reviewed PR goes **trunk → main** — the only PR that faces `main`'s rulesets.
 
 The core insight: the integration trunk is a "`main` surrogate" for the suite. "Never go back to `main`" really means "return to the trunk instead, until the very end."
+
+---
+
+## Trunk naming convention
+
+`<module>`, `<KEY>`, `<slug>` in this document are **placeholders** — substitute the real values. Do NOT copy the literal examples (`monthly-statement`, `BK-742`); they only illustrate the shape.
+
+The trunk name derives from the **suite's scope** (the `/test-automation` planning scope that opened it):
+
+| Scope (from `/test-automation`) | Trunk name pattern | Example |
+| --- | --- | --- |
+| **Module-driven** (Macro) — a whole module | `test/<module-slug>-suite` | `test/monthly-statement-suite` |
+| **Ticket-driven** (Medium) — one user story split across several PRs | `test/<STORY-KEY>-<slug>-suite` | `test/BK-742-checkout-suite` |
+| **Regression-driven** (Micro) — a single TC | usually **no trunk** — one `test/{KEY}-{slug}` branch straight to a normal PR; only spin up a trunk if the single TC genuinely fans into multiple chained PRs |
+
+Rule of thumb: the trunk is named after **whatever the suite is about** — a module slug when automating a module, the story key+slug when chaining PRs under one story. The `-suite` suffix is deliberate and scope-neutral: a single trunk collects whatever the chained PRs are — E2E specs, integration specs, or a mix of UI and API ATCs — so `-suite` covers all of them without implying the work is only end-to-end. Keep it lowercase, hyphen-separated, ≤50 chars, and unique per live suite.
 
 ---
 
@@ -27,7 +43,7 @@ The core insight: the integration trunk is a "`main` surrogate" for the suite. "
               │  ① integration trunk = local surrogate-main for the suite
               ▼
    ┌────────────────────────────────────────────────────────────────────────┐
-   │   test/monthly-statement-e2e        ←  INTEGRATION TRUNK (ephemeral)      │
+   │   test/monthly-statement-suite        ←  INTEGRATION TRUNK (ephemeral)      │
    │   created off main + pushed immediately so ticket PRs have a target       │
    └────────────────────────────────────────────────────────────────────────┘
         │
@@ -46,7 +62,7 @@ The core insight: the integration trunk is a "`main` surrogate" for the suite. "
         │
         ▼
    ┌────────────────────────────────────────────────────────────────────────┐
-   │   test/monthly-statement-e2e   (now carries every ticket + plus history)  │
+   │   test/monthly-statement-suite   (now carries every ticket + plus history)  │
    └────────────────────────────────────────────────────────────────────────┘
               │
               │  ④ SYNC GATE: git merge origin/main   (after every upstream PR is on main)
@@ -65,7 +81,7 @@ For each ticket `{KEY}` (the issue key from the TMS, e.g. `{{PROJECT_KEY}}-757`)
 
 ```bash
 # 0. Start from a clean, up-to-date trunk
-git checkout test/<module>-e2e
+git checkout test/<module>-suite
 git pull --ff-only                       # the trunk moves forward only
 
 # 1. Cut the ticket branch FROM the trunk (never from the previous ticket branch)
@@ -85,7 +101,7 @@ git push -u origin test/{KEY}-{slug}
 #    trigger the Sanity/smoke suite via GitHub Actions (/regression-testing, workflow_dispatch)
 
 # 5. PR INTO the trunk (NOT main)
-gh pr create --base test/<module>-e2e --head test/{KEY}-{slug}
+gh pr create --base test/<module>-suite --head test/{KEY}-{slug}
 
 # 6. Review loop
 #    - address Critical + High; triage Low; re-run Sanity after fixes
@@ -140,13 +156,13 @@ A **Plus Branch** is inserted between the end of one ticket and the start of the
 
 ```bash
 # After finishing a ticket, before cutting the next:
-git checkout test/<module>-e2e
+git checkout test/<module>-suite
 git pull --ff-only
 git checkout -b chore/<batch-descriptor>     # or docs/<...>, fix/<...>
 git add <only the adjacent files>            # be surgical — never `git add .`
 git commit -m "chore: <what>"
 git push -u origin chore/<batch-descriptor>
-gh pr create --base test/<module>-e2e ...    # PR into the trunk like the rest
+gh pr create --base test/<module>-suite ...    # PR into the trunk like the rest
 gh pr merge --merge
 ```
 
@@ -172,7 +188,7 @@ Consequences:
 **Mitigation (always applies, regardless of how upstream merged)** — right before opening the final PR, once every upstream PR is on `main`, run inside the trunk:
 
 ```bash
-git checkout test/<module>-e2e
+git checkout test/<module>-suite
 git fetch origin
 git merge origin/main          # merge, NOT rebase (forward-only; no force-push on a pushed branch)
 ```
@@ -194,7 +210,7 @@ This is the **only** PR that must satisfy `main`'s branch protection (required c
 
 Title the final PR after the **suite**, not a single ticket (e.g. `test(monthly-statement): automate E2E suite {KEY1}…{KEYn}`), and list the contained tickets + their TC IDs in the body for TMS traceability. Use the `references/pr-test-automation.md` body structure.
 
-After the final PR merges and CI is green on `main`, delete the trunk (`git push origin --delete test/<module>-e2e`); the next suite starts a fresh trunk.
+After the final PR merges and CI is green on `main`, delete the trunk (`git push origin --delete test/<module>-suite`); the next suite starts a fresh trunk.
 
 ---
 
@@ -221,7 +237,7 @@ A suite spans many ticket branches and multiple `/test-automation` invocations. 
 
 **When to append a `git:` line** (each is one snapshot):
 
-- Trunk created off `main` (suite start) → `trunk test/<module>-e2e@<sha> | pending: <KEY..KEY> | sync-gate: no | final-PR: none`
+- Trunk created off `main` (suite start) → `trunk test/<module>-suite@<sha> | pending: <KEY..KEY> | sync-gate: no | final-PR: none`
 - Ticket merged `--no-ff` into the trunk → `trunk …@<new-sha> | merged test/{KEY} --no-ff | pending: <remaining KEYs> | …`
 - Plus Branch merged → `… | merged chore/<desc> --no-ff | …`
 - Sync gate run (`git merge origin/main`) → `… | sync-gate: done | …`
@@ -231,7 +247,7 @@ A suite spans many ticket branches and multiple `/test-automation` invocations. 
 **Recommended line shape** (append-only — never edit a prior one):
 
 ```
-- git: trunk test/monthly-statement-e2e@a1b2c3d | merged test/BK-757 --no-ff | pending: BK-758..BK-761 | sync-gate: no | final-PR: none
+- git: trunk test/monthly-statement-suite@a1b2c3d | merged test/BK-757 --no-ff | pending: BK-758..BK-761 | sync-gate: no | final-PR: none
 ```
 
 **On resume (Phase 0)**: read the tail of `progress.md`, take the **last** `git:` line. It tells the resuming session: the trunk name + tip SHA, which tickets are already merged, which remain, whether the sync gate has run, and whether the final PR is open. From there, continue the per-ticket loop — cut the next pending ticket from the (updated) trunk. This is the reinforcement that keeps the SDET flow on track even if a later session has lost the strategy context.
@@ -240,7 +256,7 @@ A suite spans many ticket branches and multiple `/test-automation` invocations. 
 
 ## Setup checklist (one-time, per suite)
 
-1. Pick the trunk name: `test/<module>-e2e` (e.g. `test/monthly-statement-e2e`).
+1. Pick the trunk name: `test/<module>-suite` (e.g. `test/monthly-statement-suite`).
 2. Cut it off `main` and push it so ticket PRs have a target. (The Branch operation does this on demand — the trunk is NOT created by Strategy Setup.)
 3. Confirm any prerequisite upstream PRs the trunk base already contains are queued to merge to `main` so the sync gate can later cancel them.
 4. Park current adjacent uncommitted work for a later Plus Branch (or `git stash` it) — keep it out of ticket branches.

--- a/.claude/skills/git-flow-master/references/strategy-setup.md
+++ b/.claude/skills/git-flow-master/references/strategy-setup.md
@@ -71,7 +71,7 @@ For the resolved strategy, ensure the long-lived branches in this table exist. *
 | `gitflow`          | `main` + `develop`                                                              | `develop` (hotfix off `main`, release off `develop`) | `release/*` → `main` (+ back-merge to `develop`) | `main`            |
 | `github-flow`      | `main` only                                                                     | `main`                                        | n/a (PR → `main`)                               | `main`            |
 | `gitlab-flow`      | `main` + env branches (`pre-production`, `production`)                           | `main`                                        | `main` → `pre-production` → `production`        | `production`      |
-| `sdet`             | `main` only (the integration trunk `test/<module>-e2e` is ephemeral per-suite — created on demand by the Branch operation, NOT at setup) | integration trunk (per suite)                 | trunk → `main` (single final PR, per suite)     | `main`            |
+| `sdet`             | `main` only (the integration trunk `test/<module>-suite` is ephemeral per-suite — created on demand by the Branch operation, NOT at setup) | integration trunk (per suite)                 | trunk → `main` (single final PR, per suite)     | `main`            |
 
 **Branch-creation rules**:
 
@@ -80,7 +80,7 @@ For the resolved strategy, ensure the long-lived branches in this table exist. *
 - `gitflow`: ensure `develop` (create off `main` if missing); do not create `release/*` / `hotfix/*` at setup.
 - `gitlab-flow`: ensure `pre-production` and `production` (create off `main` in pipeline order if missing).
 - `enterprise`: ensure integration off `main`; `release/*` / `feature/*` are on-demand only.
-- `sdet`: ensure `main` only at setup — create NO integration branch. The per-suite trunk `test/<module>-e2e` is created off `main` by the Branch operation when a suite starts and deleted after the final PR; it is never materialized at Strategy Setup time and is never ff-synced (it carries `--no-ff` merge commits by design).
+- `sdet`: ensure `main` only at setup — create NO integration branch. The per-suite trunk `test/<module>-suite` is created off `main` by the Branch operation when a suite starts and deleted after the final PR; it is never materialized at Strategy Setup time and is never ff-synced (it carries `--no-ff` merge commits by design).
 
 Always **propose** each branch creation (which branch, off what, why) and wait for OK. Never `git checkout -b` / `git branch` silently.
 


### PR DESCRIPTION
## Summary

Follow-up to #5. Two clarity fixes on the `sdet` trunk naming, after review feedback that the example branch name could read as a fixed name and that the suffix was too E2E-specific.

1. **Scope-aware naming convention** — new block in `sdet-integration-trunk.md` stating that `<module>` / `<KEY>` / `<slug>` are placeholders to substitute (do not copy the `monthly-statement` / `BK-742` examples), and that the trunk name derives from the suite scope:
   - module-driven → `test/<module-slug>-suite`
   - ticket-driven (one story split across PRs) → `test/<STORY-KEY>-<slug>-suite`
   - regression-driven (single TC) → usually no trunk
2. **Suffix rename `-e2e` → `-suite`** across all sdet references. The trunk collects whatever the chained PRs are — E2E specs, integration specs, or mixed UI/API ATCs — so `-suite` is scope-neutral and does not imply end-to-end-only.

## Changes

- docs(sdet): scope-aware trunk naming + rename suffix -e2e -> -suite

Files: git-flow-master/{SKILL.md, references/sdet-integration-trunk.md, branching-strategies.md, strategy-setup.md, pr-templating.md}, agentic-qa-core/references/session-management.md.

## Test Plan

- [x] `bun run skills:check` — pass (14/14)
- [x] `bun run skills:registry:check` — up to date
- [x] `bun run vars:check` — 0 errors
- [x] `bun run format:check` — pass
- [x] no stray trunk `-e2e` remains (only legit `testing-e2e` category, CI `full-e2e` job, eval names)

## Risk

Docs-only. Pure terminology/clarity; no behaviour change. `-suite` is the new trunk suffix going forward.
