### PR TITLE
feat(installer): install wokitoki user-skill from agentic-user-skills

### DIFF
--- a/cli/install.ts
+++ b/cli/install.ts
@@ -283,6 +283,9 @@ const USER_LEVEL_SKILLS: ReadonlyArray<CommunitySkill> = [
   { package: 'https://github.com/obra/superpowers', skill: 'brainstorming' },
   { package: 'https://github.com/lewislulu/html-ppt-skill', skill: 'html-ppt' },
   { package: 'https://bun.sh/docs', skill: 'bun' },
+  // Cross-project human-in-the-loop feedback CLI (`toki`): a blocking browser UI
+  // the AI drives mid-conversation to collect structured, anchored answers.
+  { package: 'https://github.com/upex-galaxy/agentic-user-skills', skill: 'wokitoki' },
 ];
 
 // Matches Claude Code ${VAR} and ${VAR:-default} placeholders in .mcp.json.


### PR DESCRIPTION
Adds `wokitoki` (`toki`) to `USER_LEVEL_SKILLS` in `cli/install.ts` so the installer provisions it globally (`bunx skills add --global … --skill wokitoki`).

WokiToki is a cross-project, blocking browser feedback CLI the AI invokes mid-conversation to collect structured, anchored, point-by-point answers — user-level, not per-project. It now lives in its own repo (single source): https://github.com/upex-galaxy/agentic-user-skills

- `bun run repo:check` green (incl. T4 USER_LEVEL_SKILLS shape + TIER-MISMATCH).
- One-line additive change; no other behavior touched.