### PR TITLE
Parametrization artifact-economy doctrine

### DIFF
--- a/.claude/skills/REGISTRY.md
+++ b/.claude/skills/REGISTRY.md
@@ -1,6 +1,6 @@
 # Skill Registry (auto-generated)
 
-> Generated: `2026-06-14T02:53:11.841Z`
+> Generated: `2026-06-15T20:21:54.416Z`
 > Generator: `bun scripts/build-skill-registry.ts`
 > Protocol: `.claude/skills/agentic-qa-core/references/skill-resolver.md`
 
@@ -277,6 +277,7 @@ Skills indexed: 13
 - "All ACs covered" is the FLOOR, not the success bar. The ATC set must also cover risk-beyond-AC: invalid/boundary inputs, auth/error paths, state transitions, and anomalies the AC is silent on.
 - 1:N is the default: one AC maps to multiple ATCs. EP-merge collapses same-behavior inputs INSIDE one partition into a parameterized ATC — it must NEVER collapse across distinct partitions, boundaries, or states. BVA cases are required wherever a range/limit/length/date-window exists (EP alone misses off-by-one).
 - Apply techniques by trigger: EP always; BVA on ranges/limits; State-Transition for stateful flows; Decision Table when 2+ conditions interact; Pairwise when 3+ combinable factors (log the reduction).
+- Parametrize for artifact economy: same-behavior data variants → ONE parameterized `@atc` (fixture / data-factory rows iterated by the test) per partition, NOT N ATCs; split only when action / outcome / state differs. (Canon: doctrine §"Part 2.5".)
 - An AC is the business assertion; an ATC is its concrete exploration (Precondition + Action + Assertions). Run the Test-Design Checklist before finalizing the plan.
 - Plan → Code → Review, always in order. Only automate `Candidate` verdicts from `/test-documentation`.
 - Fixture selection: API-only → `{ api }` (no browser); UI-only → `{ ui }`; hybrid → `{ test }`.
@@ -298,6 +299,7 @@ Skills indexed: 13
 - Documenting an AC→TC map is the FLOOR (≥1 TC per AC is a minimum, never a target). Coverage = AC-conformance + risk-beyond-AC; the TC set must include boundary / negative / state / anomaly cases the AC is silent on.
 - 1:N applies to DERIVATION (consider many cases by technique), not to the REGRESSION repository. Only regression-worthy scenarios (Candidate/Manual) are persisted there; most are Deferred. jira-native: Stage 4 CREATES `Test`s for those only (Deferred = report-only). jira-xray: sprint `Test`s already exist (Stage 1) — Stage 4 PROMOTES the regression-worthy into the Test Plan + enriches them. Document because it will be re-run, never to hit a count.
 - Apply techniques by trigger: EP always; BVA wherever a range/limit/length/date-window exists; State-Transition for stateful entities; Decision Table when 2+ conditions interact; Pairwise when 3+ combinable factors.
+- Parametrize for artifact economy: same-behavior data variants → ONE Test (`Scenario Outline` + `Examples` rows) per partition, NOT N separate Tests; split only when action / outcome / status / state differs. (Canon: doctrine §"Part 2.5".)
 - Cross-cutting characteristics (XSS, perf, a11y) deferred to app-level suites are an EXPLICIT handoff, not a silent drop — name the receiving suite or file the gap.
 - Documents already-validated behavior only — not an exploration tool (exploration belongs to `/sprint-testing`).
 - TC identity = Precondition + Action + verifiable outcome. Naming: `Validate <CORE> <CONDITIONAL>`. Reject `"Login test"`, `"Login - error"`, `"TC1: Test form"`.

--- a/.claude/skills/agentic-qa-core/references/test-design-doctrine.md
+++ b/.claude/skills/agentic-qa-core/references/test-design-doctrine.md
@@ -182,6 +182,47 @@ explicit and logged — never a silent omission disguised as "covered".
 
 ---
 
+## Part 2.5 — Parametrization: one artifact, many data rows (artifact economy)
+
+Deriving widely (Principle 4) does NOT mean authoring one artifact per data value.
+The lever that keeps coverage high while artifact count low is **parametrization**:
+
+> **One parameterized artifact per equivalence partition** — same preconditions,
+> same actions, **only the data varies**, same expected outcome-shape. The varying
+> rows (boundaries, valid representatives, distinct invalid inputs of the *same*
+> behavior) live INSIDE that one artifact, not as N separate test cases / ATCs.
+
+This is the operational consequence of EP + BVA, stated as doctrine so it is not
+re-derived ad hoc:
+
+- **Parametrize when**: precondition + action are fixed and only the input data
+  changes while the *outcome behavior* is the same (e.g. every invalid-credential
+  variant → 401). Render the variants as data rows; one artifact.
+- **Split when**: the action, the outcome, the status code, or the system state
+  differs (e.g. valid → 200, locked → 423, at `max+1` → 400). Different behavior
+  = different artifact, even if the input field is the same.
+- **The split rule and the explode rule are the same rule** seen from two sides:
+  explode *across* partitions/boundaries/states (separate artifacts); collapse
+  *within* a partition (data rows in one artifact). Parametrization is the
+  collapse half; it never erases a distinct partition/boundary/state.
+
+**Two materializations of the same doctrine** (the downstream skills own the
+syntax, not this file):
+
+| Layer | One parameterized artifact = | Where the data rows live |
+|---|---|---|
+| Manual / TMS (`test-documentation`) | one Gherkin `Scenario Outline` Test | the `Examples:` table (one block per partition) |
+| Automation / KATA (`test-automation`) | one parameterized `@atc` | a fixture file / data factory iterated by the test |
+
+Net effect: a money-withdrawal AC with ~20 derived cases may become **3–5
+parameterized artifacts** (valid-range outline, below/above-min boundary outline,
+account-state outline, decision-rule outline) — each carrying many data rows —
+instead of 20 artifacts. Coverage is unchanged; the TMS / suite stays legible.
+Combinatorial techniques (Decision Table, Pairwise) reduce the *rows* inside an
+`Examples`/fixture set; EP/BVA decide *how many artifacts* the rows split across.
+
+---
+
 ## Part 3 — Test-Design Checklist (the gate)
 
 Run this whenever deriving cases from an AC set. A plan that cannot answer YES (or
@@ -202,6 +243,8 @@ a justified N/A) to each is not done.
          (or N/A: stateless)
 [ ] DT   2+ interacting conditions → decision table built? (or N/A: ≤1 condition)
 [ ] PW   3+ combinable factors → pairwise applied + logged? (or N/A: <3 factors)
+[ ] PARAM Same-behavior data variants collapsed into ONE parameterized artifact
+         per partition (Examples / fixture rows), not N separate artifacts?
 [ ] RISK Cases prioritized; any scope-driven drop logged explicitly?
 ```
 

--- a/.claude/skills/test-automation/SKILL.md
+++ b/.claude/skills/test-automation/SKILL.md
@@ -42,6 +42,7 @@ Requires `agentic-qa-core`. Loads on demand:
 - "All ACs covered" is the FLOOR, not the success bar. The ATC set must also cover risk-beyond-AC: invalid/boundary inputs, auth/error paths, state transitions, and anomalies the AC is silent on.
 - 1:N is the default: one AC maps to multiple ATCs. EP-merge collapses same-behavior inputs INSIDE one partition into a parameterized ATC — it must NEVER collapse across distinct partitions, boundaries, or states. BVA cases are required wherever a range/limit/length/date-window exists (EP alone misses off-by-one).
 - Apply techniques by trigger: EP always; BVA on ranges/limits; State-Transition for stateful flows; Decision Table when 2+ conditions interact; Pairwise when 3+ combinable factors (log the reduction).
+- Parametrize for artifact economy: same-behavior data variants → ONE parameterized `@atc` (fixture / data-factory rows iterated by the test) per partition, NOT N ATCs; split only when action / outcome / state differs. (Canon: doctrine §"Part 2.5".)
 - An AC is the business assertion; an ATC is its concrete exploration (Precondition + Action + Assertions). Run the Test-Design Checklist before finalizing the plan.
 
 **Test-automation operational rules:**

--- a/.claude/skills/test-automation/references/planning-playbook.md
+++ b/.claude/skills/test-automation/references/planning-playbook.md
@@ -409,6 +409,14 @@ async {methodName}({params}): {ReturnType} { /* ... */ }
 **Boundary Value Analysis detail** (mandatory if any range/limit exists — else state N/A):
 | Field + range | Boundary ATCs (`min-1·min·min+1 … max-1·max·max+1`, zero/empty/null) |
 
+**Two reduction axes — keep them separate** (canon: doctrine §"Part 2.5"):
+- **EP/BVA decide the ATC COUNT** — how many parameterized `@atc`s the cases split across (one per partition + boundary + state).
+- **Decision Table / Pairwise reduce the DATA ROWS inside one parameterized ATC** — when an ATC's data set combines 2+ interacting conditions (Decision Table → one row per surviving rule) or 3+ factors (Pairwise → all-pairs rows instead of the full cartesian product). They shrink the fixture/`data-factory` row set, NOT the ATC count. Log the reduction in the fixture or the spec so it is visible, not a silent cap.
+
+| Parameterized ATC | Reduction applied | Rows after reduction |
+|---|---|---|
+| (per multi-factor ATC) | Decision Table / Pairwise / none | … |
+
 ## 7. Dependencies
 - Precondition Steps
 - Required Components (exists? action needed)

--- a/.claude/skills/test-documentation/SKILL.md
+++ b/.claude/skills/test-documentation/SKILL.md
@@ -44,6 +44,7 @@ Requires `agentic-qa-core`. Loads on demand:
 - Documenting an AC→TC map is the FLOOR (≥1 TC per AC is a minimum, never a target). Coverage = AC-conformance + risk-beyond-AC; the TC set must include boundary / negative / state / anomaly cases the AC is silent on.
 - 1:N applies to DERIVATION (consider many cases by technique), not to the REGRESSION repository. Only regression-worthy scenarios (Candidate/Manual) are persisted there; most are Deferred. jira-native: Stage 4 CREATES `Test`s for those only (Deferred = report-only). jira-xray: sprint `Test`s already exist (Stage 1) — Stage 4 PROMOTES the regression-worthy into the Test Plan + enriches them. Document because it will be re-run, never to hit a count.
 - Apply techniques by trigger: EP always; BVA wherever a range/limit/length/date-window exists; State-Transition for stateful entities; Decision Table when 2+ conditions interact; Pairwise when 3+ combinable factors.
+- Parametrize for artifact economy: same-behavior data variants → ONE Test (`Scenario Outline` + `Examples` rows) per partition, NOT N separate Tests; split only when action / outcome / status / state differs. (Canon: doctrine §"Part 2.5".)
 - Cross-cutting characteristics (XSS, perf, a11y) deferred to app-level suites are an EXPLICIT handoff, not a silent drop — name the receiving suite or file the gap.
 
 **Test-documentation operational rules:**

--- a/.claude/skills/test-documentation/references/tms-conventions.md
+++ b/.claude/skills/test-documentation/references/tms-conventions.md
@@ -340,6 +340,15 @@ And the average rating {average} = sum of ratings / {N}
 
 ### Variables table (mandatory in TC Description)
 
+> **`Examples:` vs `Variables` — two different tables, do not conflate.** The
+> `Examples:` table (in the Gherkin §"Gherkin") supplies the **varying data values
+> per equivalence partition** — *what* changes each parameterized run (the
+> artifact-economy lever, doctrine §"Part 2.5"). The `Variables` table (here, in
+> the Description) explains **how to OBTAIN each variable at runtime** (the SQL /
+> source query) — it does not vary per run. Rule of thumb: a value that *changes
+> the case* → an `Examples` column; a value you must *look up to run the case* → a
+> `Variables` row. A parameterized TC typically has BOTH.
+
 Every TC with variables must include a table explaining how to obtain each one:
 
 ```


### PR DESCRIPTION
Adds doctrine Part 2.5 (one parameterized artifact per equivalence partition; Gherkin Examples for manual/TMS + fixture/data-factory rows for KATA), a PARAM checklist line, and propagation to test-documentation + test-automation compact rules. Also clarifies EP/BVA-decide-artifact-count vs Decision-Table/Pairwise-reduce-data-rows (planning-playbook), and contrasts the Examples vs Variables tables (tms-conventions). Docs only; all gates green.