### PR TITLE
feat(git-flow-master): port git:policy and record the accepted ruleset divergence

### DIFF
--- a/.agents/project.yaml
+++ b/.agents/project.yaml
@@ -69,7 +69,7 @@ qa:
 # updater (bootstrapOnly), so each project keeps its own. Filled by git-flow-master, NOT by
 # `agents:setup`. These leaves are read directly (not {{VAR}} template vars) → skipped by vars:check.
 git_strategy:
-  strategy: solo-main # null until Strategy Setup runs; then one of: solo-main | main-integration | enterprise | trunk-based | gitflow | github-flow | gitlab-flow | sdet
+  strategy: solo-main # DEFAULT, not a decision — see meta.strategy_source. One of: solo-main | main-integration | enterprise | trunk-based | gitflow | github-flow | gitlab-flow | sdet
   description: >
     Single long-lived branch (main); single maintainer (this repo is the boilerplate
     template itself). Work is committed and pushed DIRECTLY to main — never via a PR, and
@@ -95,7 +95,7 @@ git_strategy:
   policy: # how strictly protected branches are guarded (set by Strategy Setup Q4; defaults are safe)
     direct_push_to_protected: allowed # forbidden | confirm | allowed (solo-main = allowed)
     admin_bypass: true # normal flow here: the admin push credential auto-bypasses the ProtectPublic ruleset on every push (no flag needed). "Bypassed rule violations" is expected — never open a PR.
-    require_pr_reviews: 0 # null | 0 | N — min approvals before merge to a protected branch (informational)
+    require_pr_reviews: 1 # VERIFIED 2026-08-18 against ruleset 16809536: required_approving_review_count = 1. Informational here, because this repo pushes directly and the admin credential bypasses the rule (see description) — but the number must still state what the host asks of anyone who does open a PR.
   branch_prefixes:
     precedence: [feat, fix, refactor, test, docs, chore]
     naming_with_key: '{prefix}/{ISSUE-KEY}-{kebab-slug}'
@@ -103,6 +103,12 @@ git_strategy:
   meta:
     setup_version: 1
     created: 2026-06-20 # YYYY-MM-DD stamped by Strategy Setup
+    policy_verified: 2026-08-18 # YYYY-MM-DD of the last `bun run git:policy verify`. null = never reconciled against the host
+    policy_source: declared # verified | declared. Stays `declared` while the accepted divergence below is open — see the note on direct_push_to_protected
+    # Did anyone actually CHOOSE this strategy, or is it just the shipped default?
+    # `strategy:` above is never null, so its value alone cannot answer that. Strategy
+    # Setup flips this to `chosen` when the questionnaire actually runs.
+    strategy_source: inherited # inherited | chosen
 
 # Per-environment config. Add/remove environments freely (production, dev, qa, uat, etc.).
 # Each environment must define ALL four keys: web_url, api_url, db_mcp, api_mcp.

--- a/.claude/skills/REGISTRY.md
+++ b/.claude/skills/REGISTRY.md
@@ -1,6 +1,6 @@
 # Skill Registry (auto-generated)
 
-> Generated: `2026-07-31T05:52:01.182Z`
+> Generated: `2026-08-18T06:51:29.923Z`
 > Generator: `bun scripts/build-skill-registry.ts`
 > Protocol: `.claude/skills/agentic-qa-core/references/skill-resolver.md`
 
@@ -160,9 +160,9 @@ Skills indexed: 15
 - Unpushed / unpulled commits (ahead / behind upstream).
 - Upstream status (no upstream, up-to-date, diverged).
 - Remote name(s) — most repos have one (`origin`); some have a fork + upstream.
-- **`git_strategy:` block in `.agents/project.yaml`** — read it. If `git_strategy.strategy` is non-null (one of the eight slugs), it + `git_strategy.branches` (production / integration / ephemeral_pattern) + `git_strategy.decisions` (promote_method / feature_merge / hotfix_policy) ARE the persisted decision — use them. Each `git_strategy.decisions.*` field whose value is NOT `n/a`/empty means Strategy Setup SKIPS that question on re-run (idempotent — idempotency is keyed off the `git_strategy.decisions.*` fields, not markers). **Inherited-template guard:** the boilerplate ships the block FILLED (`strategy: solo-main`) and a scaffolded project INHERITS it verbatim (the scaffolder only patches `project.project_name` / `project.project_key`). So a non-null `git_strategy.strategy` is only authoritative when the project is actually onboarded. Read `project.project_name` in the SAME file: if `git_strategy.strategy` is non-null BUT `project.project_name` is `null`, the block was INHERITED from the template (not chosen for THIS project) — treat the strategy as UNCONFIRMED and route to the Bootstrap trigger's inherited case (it still operates under the inherited strategy if the offer is declined). If `project.project_name` is set, the block is confirmed → use it normally, no nudge.
-- **Single-branch heuristic** — `git branch -a` shows only `main` (or `master`) and no integration branch in the remote → `solo-main`.
-- **Two-branch heuristic** — exactly `main` (or `master`) + one of `{staging, dev, develop, integration}` exists upstream → `main-integration` (record the integration branch name).
+- **A `404` from `branches/{b}/protection` does NOT mean the branch is unprotected.** A repo governed by rulesets returns `404` there while enforcing PR requirements, approvals, signed commits and non-fast-forward bans through `rules/branches/{b}`. Stopping at the classic endpoint produces a confident "unprotected" reading on a branch that requires a reviewed pull request.
+- **A push that succeeds is not evidence of an absent rule.** Org owners and anyone on the ruleset bypass list push through while the rule still binds everyone else. When a push prints `Changes must be made through a pull request`, that was a BYPASS: report it as one, never as permission.
+- **`require_code_owner_review: true` with no `CODEOWNERS` file is unsatisfiable, not strict.** Nobody outside the bypass list can clear it, so every merge becomes a bypass.
 - (truncated — read full SKILL.md for the rest)
 
 **Read full SKILL.md when**: the compact rules above are insufficient (e.g. novel scenario, debugging, or the briefing tells you to load the full skill).

--- a/.claude/skills/git-flow-master/SKILL.md
+++ b/.claude/skills/git-flow-master/SKILL.md
@@ -85,6 +85,33 @@ This summary is cheap, prevents 90% of mistakes, and is the input to every subse
 
 ---
 
+## Step 1b — Reconcile the declared policy against the host (once per session)
+
+`git_strategy.policy.*` in `.agents/project.yaml` records what the team DECIDED. The hosting platform records what is actually ENFORCED. These drift, and the drift only surfaces at the worst moment: a merge that stalls on an approval nobody expected, or a "protected" branch that was never protected.
+
+Run this ONCE per session, at the first push / PR / merge intent (not on read-only operations), and cache the result for the rest of the session.
+
+**Run the tool; do not perform the queries by hand:**
+
+```bash
+bun run git:policy verify          # read-only; exit 1 on drift
+bun run git:policy verify --stamp  # same, and records the reconciliation when clean
+```
+
+It queries BOTH GitHub protection mechanisms for every branch in `git_strategy.branches` / `protected`, compares the union against the declared policy, and prints each divergence as `declared` vs `enforced`. The strategy-to-ruleset mapping and what the tool deliberately does not manage: `references/ruleset-parity.md`.
+
+**Why a tool rather than a checklist.** This reconciliation existed only as prose in the sibling boilerplate and kept not happening — that repo shipped `require_pr_reviews: 0` against a host demanding one approval plus a code-owner review, and it surfaced months later as a refused merge. This repo had the identical divergence. A script performs every query on every run; a procedure performs the ones the reader remembered.
+
+**Facts that still bind you when reading its output:**
+
+- **A `404` from `branches/{b}/protection` does NOT mean the branch is unprotected.** A repo governed by rulesets returns `404` there while enforcing PR requirements, approvals, signed commits and non-fast-forward bans through `rules/branches/{b}`. Stopping at the classic endpoint produces a confident "unprotected" reading on a branch that requires a reviewed pull request.
+- **A push that succeeds is not evidence of an absent rule.** Org owners and anyone on the ruleset bypass list push through while the rule still binds everyone else. When a push prints `Changes must be made through a pull request`, that was a BYPASS: report it as one, never as permission.
+- **`require_code_owner_review: true` with no `CODEOWNERS` file is unsatisfiable, not strict.** Nobody outside the bypass list can clear it, so every merge becomes a bypass.
+
+**On drift, report — never auto-correct.** Three legitimate resolutions: update `.agents/project.yaml` to match the host, change the host (`bun run git:policy apply`, dry run until `--yes`), or accept the divergence and record WHY in this project's own `CLAUDE.md`. Editing either side needs the user's choice.
+
+---
+
 ## Step 2 — Resolve the branching strategy
 
 The skill supports eight strategies (see `references/branching-strategies.md` for the full catalogue, detection signals, and trade-offs):
@@ -426,6 +453,8 @@ The branch plan that comes out of the decision is the **contract** for execution
 ## Critical rules — apply every invocation
 
 1. **Diagnose before acting.** Step 1 always runs. Never assume repo state.
+1b. **`policy:` records INTENT, not enforcement.** Reconcile it by RUNNING `bun run git:policy verify` (Step 1b) at the first push / PR / merge intent, then `--stamp` when clean. Never perform the protection queries by hand, and never state what the remote requires from a `declared` reading. `git:policy apply` is a dry run until `--yes`, and refuses to remove a guard, lower the approval bar, turn off code-owner review, or widen the merge methods unless `--allow-loosening` is passed for that specific give-up.
+1c. **`strategy: solo-main` is the shipped DEFAULT, not evidence of a decision.** `meta.strategy_source` tells them apart: `inherited` means nobody chose. On a repo whose `project.project_name` is set and whose `strategy_source` is still `inherited`, OFFER Strategy Setup and say what the default costs (no integration branch, no promotion path, no review gate). Strategy Setup stamps `chosen`; nothing else may.
 2. **One commit = one responsibility.** Never bundle unrelated changes.
 3. **No AI attribution** in commits or PR bodies. Commits look human-authored. (Critical Reminder #3 in `CLAUDE.md`.)
 4. **Confirm before pushing to any protected branch.** Strategy-driven; see Step 3.3. (Critical Reminder #5 in `CLAUDE.md`.)

--- a/.claude/skills/git-flow-master/references/ruleset-parity.md
+++ b/.claude/skills/git-flow-master/references/ruleset-parity.md
@@ -1,0 +1,98 @@
+# Ruleset Parity — the declared strategy and the enforced host, kept in one shape
+
+`git_strategy` in `.agents/project.yaml` says what the team decided. The host says what is actually enforced. This file owns the mapping between them and the tool that reconciles it: `bun run git:policy`.
+
+> **Why a tool and not a procedure.** SKILL.md Step 1b has always specified this reconciliation in prose, for an agent to carry out by hand. It kept not happening. The boilerplate itself shipped `require_pr_reviews: 0` against a host demanding one approval plus a code-owner review, and nobody noticed until a merge was refused with `the base branch policy prohibits the merge`. A script performs every query on every run, which is the one property prose cannot guarantee.
+
+---
+
+## 1. Commands
+
+| Command | Reads host | Writes host | Writes yaml | Exit |
+| --- | --- | --- | --- | --- |
+| `bun run git:policy plan` | no | no | no | 0 |
+| `bun run git:policy verify` | yes | no | no | **1 on drift**, 0 in parity |
+| `bun run git:policy verify --stamp` | yes | no | `meta.policy_verified` + `policy_source` when clean | same |
+| `bun run git:policy apply` | yes | no (dry run) | no | 0 |
+| `bun run git:policy apply --yes` | yes | **yes** | no | 0 / 1 |
+
+`apply` is a dry run by default. `--yes` is what writes. `--allow-loosening` is additionally required for any change that removes a guard or lowers the bar (see §4).
+
+---
+
+## 2. The mapping — `git_strategy` to ruleset
+
+### Which branches the ruleset covers
+
+Derived from the strategy shape, then **unioned** with whatever `protected:` already lists. An operator may protect more than the strategy implies; narrowing that silently would itself be a loosening.
+
+| Strategy | Branches covered |
+| --- | --- |
+| `solo-main`, `github-flow`, `trunk-based` | `branches.production` |
+| `main-integration`, `enterprise` | `branches.production` + `branches.integration` |
+| `gitflow` | `branches.production` + `branches.integration` (default `develop`) |
+| `gitlab-flow` | `branches.production` + `branches.integration` + `pre-production` |
+| `sdet` | `branches.production` only — the per-suite trunk is EPHEMERAL (`branches.ephemeral_pattern`) and `integration` is `null`. Protecting it would put ruleset friction on exactly the intermediate merges the strategy exists to keep frictionless. |
+
+### Which rules get written
+
+| Rule | Source | Notes |
+| --- | --- | --- |
+| `deletion` | always | every strategy protects against branch deletion |
+| `non_fast_forward` | always | blocks force-push |
+| `creation` | always | |
+| `pull_request` | **omitted** when `policy.direct_push_to_protected: allowed` | the `pull_request` rule IS what blocks a direct push. Declaring `allowed` while shipping the rule is the exact contradiction this tool exists to catch. |
+| `pull_request.required_approving_review_count` | `policy.require_pr_reviews` (`null` → `0`) | |
+| `pull_request.require_code_owner_review` | **derived** from whether a `CODEOWNERS` file exists | never declared — see §3 |
+| `pull_request.allowed_merge_methods` | `decisions.feature_merge` | `merge-commit`→`[merge]`, `squash`→`[squash]`, `rebase-merge`→`[rebase]`. On `n/a` the host's current value is **preserved**, because a non-decision must not widen what the repo permits. |
+| `required_signatures`, `required_status_checks`, anything else | **preserved from the existing ruleset** | not derivable from `git_strategy`; dropping a guard the tool has no opinion about is a silent loosening |
+
+---
+
+## 3. What this deliberately does not manage
+
+**`bypass_actors`.** Real bypass entries need GitHub actor IDs — an org-admin role, specific user IDs. That is organisation identity, not project configuration, and it must not live in a versioned per-project file that gets copied between repos. `verify` reports the bypass list; `apply` omits the field on update so the host keeps whatever is configured, and seeds an org-admin entry only when creating a ruleset from scratch on a project that declared `admin_bypass: true`.
+
+**`CODEOWNERS`.** The tool derives `require_code_owner_review` from whether the file exists rather than reading it from yaml. Turning that flag on without the file produces a requirement **nobody outside the bypass list can ever satisfy** — the merge is refused, and the only way through is a bypass, which is strictly worse than no rule. `verify` reports that combination as drift with a named remedy.
+
+**Organisation-level rulesets.** `GET /orgs/{org}/rulesets` returns `403 Upgrade to GitHub Team` on a Free plan, so the unit of configuration here is the repository. A team that later gets org rulesets should treat this tool as the per-repo layer beneath them.
+
+**Classic branch protection.** `verify` READS it, because a `404` on `branches/{b}/protection` means "not configured through that mechanism", never "unprotected". `apply` never writes it: mixing both mechanisms on one branch produces a union nobody can reason about.
+
+---
+
+## 4. The loosening guard
+
+`apply` refuses, unless `--allow-loosening` is passed, any change that:
+
+- removes a `deletion`, `non_fast_forward`, or `required_signatures` rule;
+- removes the `pull_request` rule entirely (direct pushes become possible);
+- lowers `required_approving_review_count`;
+- turns off `require_code_owner_review`;
+- permits a merge method the host currently forbids.
+
+A tool that can silently open `main` is a worse problem than the drift it fixes. The flag exists because some of these are legitimate and intended — turning off an unsatisfiable code-owner requirement, for instance — but each one has to be asked for.
+
+---
+
+## 5. When to run which
+
+**`verify` on the first push / PR / merge intent of a session.** This is Step 1b, now executable. It is read-only and cheap. `--stamp` records the reconciliation so later operations know how far the yaml can be trusted.
+
+**`apply` right after Strategy Setup**, and after any deliberate change to `git_strategy.policy`. Always read the dry run before passing `--yes`.
+
+**Never `apply` to fix a `verify` failure you have not read.** Drift has three legitimate resolutions and only one of them is "change the host": the yaml may be the wrong side, or the divergence may be intended and belong in the project's own `CLAUDE.md` → `## Git Strategy`.
+
+---
+
+## 6. Worked example — the drift this tool was built from
+
+The boilerplate declared, and the host enforced:
+
+```
+require_pr_reviews:         declared 0        enforced 1
+direct_push_to_protected:   declared allowed  enforced blocked (pull_request rule)
+require_code_owner_review:  n/a               enforced true, with no CODEOWNERS anywhere
+```
+
+The first two were fixed in the yaml (the host was right). The third was fixed on the host: with no `CODEOWNERS` file the requirement was unsatisfiable, so every merge had to bypass the ruleset. `apply` refused the change until `--allow-loosening` was passed, printed the payload first, preserved `required_signatures` and the `[merge]`-only method list, and left the bypass list untouched.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,9 +437,26 @@ Git / PR work → `/git-flow-master` auto-loads. Details in `.claude/skills/git-
 
 > **Source of truth: the `git_strategy:` block in `.agents/project.yaml`.** `git-flow-master` reads it before any git/gh operation and adapts every branch / commit / push / PR / conflict-fix to the strategy declared there. NEVER define branch policy in this CLAUDE.md: edit the `git_strategy:` block.
 >
-> If `git_strategy.strategy` is **null** (the shipped template value), the strategy is UNSET: `git-flow-master` OFFERS "Strategy Setup" on the first git intent and fills the block (it never auto-picks). `.agents/project.yaml` ships as a per-project template (all `null`) and is frozen by `bun run update` (updater `bootstrapOnlyPaths`), so every project keeps its own strategy. Downstream test-automation projects typically choose `sdet` (chained suites; see `.claude/skills/git-flow-master/references/sdet-integration-trunk.md`).
+> `git_strategy.strategy` ships **`solo-main`**, not null. That is a DEFAULT, not a decision, and `meta.strategy_source: inherited` is what records the difference. `git-flow-master` OFFERS "Strategy Setup" when a project has filled in its `project_name` and `strategy_source` is still `inherited` — a real project running a strategy nobody chose. `.agents/project.yaml` is frozen by `bun run update` (updater `bootstrapOnlyPaths`), so every project keeps its own. Downstream test-automation projects typically choose `sdet` (chained suites; see `.claude/skills/git-flow-master/references/sdet-integration-trunk.md`).
 
-This repository (the boilerplate itself) ships `git_strategy.strategy: null`; with a single `main` branch, `git-flow-master` operates as **`solo-main`** (single maintainer, commit + push directly to `main`). To pin it explicitly: ask git-flow-master to "set up our git strategy".
+This repository (the boilerplate itself) runs `solo-main`: single maintainer, commit and push directly to `main`. To pin it as a real decision rather than the inherited default, ask git-flow-master to "set up our git strategy" — that stamps `strategy_source: chosen`.
+
+### Accepted divergence — declared policy vs enforced ruleset
+
+`bun run git:policy verify` reports one drift on `main`, and it is **intended**. Do not "fix" it:
+
+```
+main.direct_push_to_protected   declared: allowed   enforced: blocked (pull_request rule)
+```
+
+The ruleset `ProtectPublic` (id `16809531`) does require a pull request on `main`. This repo pushes directly anyway, because the push credential is an org admin and sits in the ruleset's bypass list. The remote line `Bypassed rule violations ... Changes must be made through a pull request` is expected here and is not an error.
+
+Why the yaml stays `allowed` rather than being "corrected" to `confirm`: `allowed` describes how work actually lands in this repository, and it is the value `git-flow-master` reads before deciding whether to ask permission for each push. Flipping it would make every agent stop and confirm on a flow that has standing authorization.
+
+Two consequences worth knowing:
+
+- **`meta.policy_source` stays `declared`** while this divergence is open. A `verified` stamp would claim the two sides agree, and they do not.
+- **`bun run git:policy apply` must NOT be run on this repository.** With `direct_push_to_protected: allowed`, the tool derives a ruleset with **no** `pull_request` rule, so applying it would strip the requirement for everyone who is not a bypass actor. The loosening guard blocks it, and that guard is the only thing standing between this config and an open `main`. Surgical host changes here go through `gh api` directly.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test": "playwright test",
     "types:check": "tsc --noEmit",
     "up": "bun cli/update-boilerplate.ts",
+    "git:policy": "bun scripts/git-policy.ts",
     "vars:check": "bun scripts/lint-vars.ts",
     "vars:env:check": "bun scripts/check-vars.ts",
     "xray": "bun cli/xray/index.ts"

--- a/scripts/git-policy.ts
+++ b/scripts/git-policy.ts
@@ -1,0 +1,611 @@
+#!/usr/bin/env bun
+/**
+ * git-policy.ts — parity between the DECLARED git strategy and the ENFORCED host rules.
+ *
+ * `.agents/project.yaml` -> `git_strategy` records what the team decided.
+ * The hosting platform records what is actually enforced. These drift, and the
+ * drift is only discovered at the worst moment: a merge that stalls on an
+ * approval nobody expected, or a "protected" branch that was never protected.
+ *
+ * `git-flow-master`'s Step 1b already specified this reconciliation in prose,
+ * for an agent to perform by hand. That is exactly why it kept not happening —
+ * this repo shipped `require_pr_reviews: 0` against a host demanding 1 approval
+ * plus a code-owner review, and the mismatch surfaced as a refused merge.
+ * A script performs every query every time, which is the property the prose
+ * could not guarantee.
+ *
+ * COMMANDS
+ *   verify   Read the host, diff against git_strategy, report. Read-only.
+ *            `--stamp` writes meta.policy_verified / policy_source when clean.
+ *            Exit 1 on drift, 0 when in parity.
+ *   apply    Derive a ruleset from git_strategy and write it to the host.
+ *            Dry-run by DEFAULT; `--yes` performs the write.
+ *            Refuses to LOOSEN protection unless `--allow-loosening`.
+ *   plan     Print the ruleset git_strategy implies, and exit. No host calls.
+ *
+ * WHY RULESETS AND NOT CLASSIC BRANCH PROTECTION
+ * `branches/{b}/protection` returns 404 on a repo governed by rulesets while
+ * every rule still binds. `verify` therefore queries BOTH and treats a classic
+ * 404 as "not configured through that mechanism", never as "unprotected".
+ * `apply` only ever writes rulesets: mixing the two mechanisms on one branch
+ * produces a union nobody can reason about.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT MANAGE
+ *   - `bypass_actors` beyond the org-admin role. Real actor IDs are org
+ *     identity, not project config, and must not live in a versioned per-project
+ *     file. `verify` reports them; `apply` preserves whatever is already there.
+ *   - CODEOWNERS. `require_code_owner_review` is derived from whether the file
+ *     actually exists, because turning it on without one produces a requirement
+ *     nobody outside the bypass list can ever satisfy.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+
+import pc from 'picocolors';
+import { parse as parseYaml } from 'yaml';
+
+const REPO_ROOT = join(import.meta.dir, '..');
+const PROJECT_YAML = join(REPO_ROOT, '.agents', 'project.yaml');
+const RULESET_NAME = 'ProtectPublic';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface GitStrategy {
+  strategy: string
+  branches: { production: string | null, integration: string | null, ephemeral_pattern: string | null }
+  protected: string[]
+  decisions: { promote_method: string, feature_merge: string, hotfix_policy: string }
+  policy: { direct_push_to_protected: string, admin_bypass: boolean, require_pr_reviews: number | null }
+  meta: Record<string, unknown>
+}
+
+interface PullRequestParams {
+  required_approving_review_count: number
+  require_code_owner_review: boolean
+  required_review_thread_resolution: boolean
+  dismiss_stale_reviews_on_push: boolean
+  require_last_push_approval: boolean
+  allowed_merge_methods: string[]
+}
+
+interface Rule { type: string, parameters?: Record<string, unknown> }
+
+interface Finding {
+  severity: 'drift' | 'info'
+  field: string
+  declared: string
+  enforced: string
+  note?: string
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+const log = {
+  info: (m: string) => console.log(`${pc.blue('i')} ${m}`),
+  ok: (m: string) => console.log(`${pc.green('✔')} ${m}`),
+  warn: (m: string) => console.log(`${pc.yellow('▲')} ${m}`),
+  err: (m: string) => console.log(`${pc.red('✖')} ${m}`),
+  dim: (m: string) => console.log(pc.dim(`  ${m}`)),
+};
+
+function fail(msg: string): never {
+  log.err(msg);
+  process.exit(1);
+}
+
+/** `gh api` wrapper. Returns null on any non-zero exit (404 / 403 / no network). */
+function gh(path: string, args: string[] = []): unknown | null {
+  const p = Bun.spawnSync(['gh', 'api', path, ...args], { stdout: 'pipe', stderr: 'pipe' });
+  if (p.exitCode !== 0) { return null; }
+  const out = p.stdout.toString().trim();
+  if (out === '') { return null; }
+  try { return JSON.parse(out); }
+  catch { return null; }
+}
+
+function ghExitCode(path: string): number {
+  return Bun.spawnSync(['gh', 'api', path], { stdout: 'pipe', stderr: 'pipe' }).exitCode ?? 1;
+}
+
+function readStrategy(): GitStrategy {
+  if (!existsSync(PROJECT_YAML)) { fail(`.agents/project.yaml not found at ${PROJECT_YAML}`); }
+  const doc = parseYaml(readFileSync(PROJECT_YAML, 'utf8')) as Record<string, unknown>;
+  const gs = doc?.git_strategy as GitStrategy | undefined;
+  if (!gs) { fail('`git_strategy:` block missing from .agents/project.yaml. Run Strategy Setup first ("set up our git strategy").'); }
+  if (!gs.strategy || gs.strategy === 'null') { fail('`git_strategy.strategy` is unset. Run Strategy Setup first.'); }
+  return gs;
+}
+
+/** `owner/repo` from the origin remote. */
+function readSlug(): string {
+  const p = Bun.spawnSync(['git', '-C', REPO_ROOT, 'remote', 'get-url', 'origin'], { stdout: 'pipe', stderr: 'pipe' });
+  if (p.exitCode !== 0) { fail('No `origin` remote — cannot resolve the repository.'); }
+  const url = p.stdout.toString().trim();
+  const m = url.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
+  if (!m) { fail(`origin is not a GitHub remote: ${url}`); }
+  return `${m[1]}/${m[2]}`;
+}
+
+function hasCodeowners(): boolean {
+  return ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS']
+    .some(p => existsSync(join(REPO_ROOT, p)));
+}
+
+// ---------------------------------------------------------------------------
+// The mapping: git_strategy -> ruleset
+// ---------------------------------------------------------------------------
+
+/**
+ * Branches a strategy protects. Derived from the strategy shape, then unioned
+ * with whatever `protected:` already lists — an operator may protect more than
+ * the strategy implies, and narrowing that silently would be a loosening.
+ */
+export function protectedBranches(gs: GitStrategy): string[] {
+  const prod = gs.branches?.production ?? 'main';
+  const integ = gs.branches?.integration ?? null;
+  const byStrategy: Record<string, (string | null)[]> = {
+    'solo-main': [prod],
+    'github-flow': [prod],
+    'trunk-based': [prod],
+    'main-integration': [prod, integ],
+    'enterprise': [prod, integ],
+    'gitflow': [prod, integ ?? 'develop'],
+    'gitlab-flow': [prod, integ, 'pre-production'],
+    // `sdet` runs an EPHEMERAL per-suite trunk (`branches.ephemeral_pattern`) with
+    // `integration: null`. Protecting it would put ruleset friction on exactly the
+    // intermediate merges the strategy exists to keep frictionless, so only the
+    // production branch is covered. Listed explicitly rather than left to the
+    // default, because "the default happened to be right" is not a decision.
+    'sdet': [prod],
+  };
+  const base = byStrategy[gs.strategy] ?? [prod];
+  const declared = Array.isArray(gs.protected) ? gs.protected : [];
+  return [...new Set([...base, ...declared].filter((b): b is string => typeof b === 'string' && b.length > 0))];
+}
+
+/** `feature_merge` decides which merge button the host offers. */
+export function allowedMergeMethods(gs: GitStrategy): string[] | null {
+  switch (gs.decisions?.feature_merge) {
+    case 'squash': return ['squash'];
+    case 'rebase-merge': return ['rebase'];
+    case 'merge-commit': return ['merge'];
+    default: return null; // `n/a` — no decision; the caller preserves the host value
+  }
+}
+
+/**
+ * The ruleset `git_strategy` implies.
+ *
+ * `direct_push_to_protected: allowed` omits the `pull_request` rule entirely —
+ * that rule IS what blocks a direct push. Declaring "allowed" while shipping the
+ * rule is the contradiction this whole script exists to catch.
+ */
+export const MANAGED_RULE_TYPES = new Set(['deletion', 'non_fast_forward', 'creation', 'pull_request']);
+
+export function buildRules(gs: GitStrategy, codeowners: boolean, current: Rule[] = []): Rule[] {
+  const rules: Rule[] = [
+    { type: 'deletion' },
+    { type: 'non_fast_forward' },
+    { type: 'creation' },
+  ];
+
+  if (gs.policy?.direct_push_to_protected !== 'allowed') {
+    const currentPr = current.find(r => r.type === 'pull_request');
+    const currentMethods = (currentPr?.parameters as Partial<PullRequestParams> | undefined)?.allowed_merge_methods;
+    const params: PullRequestParams = {
+      required_approving_review_count: gs.policy?.require_pr_reviews ?? 0,
+      // Derived, never declared: the flag without the file is unsatisfiable.
+      require_code_owner_review: codeowners,
+      required_review_thread_resolution: true,
+      dismiss_stale_reviews_on_push: true,
+      require_last_push_approval: false,
+      // `feature_merge: n/a` means the project made no decision here, so the
+      // host's existing setting is the only real answer — overwriting it with
+      // "all three" would WIDEN what the repo permits on the strength of a
+      // non-decision.
+      allowed_merge_methods: allowedMergeMethods(gs) ?? currentMethods ?? ['merge', 'squash', 'rebase'],
+    };
+    rules.push({ type: 'pull_request', parameters: params as unknown as Record<string, unknown> });
+  }
+
+  // Carry forward every rule this tool does not model (required_signatures,
+  // required_status_checks, ...). They are not derivable from `git_strategy`,
+  // and dropping a guard because the tool has no opinion about it is exactly
+  // the silent loosening this design refuses to perform.
+  for (const r of current) {
+    if (!MANAGED_RULE_TYPES.has(r.type)) { rules.push(r); }
+  }
+
+  return rules;
+}
+
+// ---------------------------------------------------------------------------
+// verify
+// ---------------------------------------------------------------------------
+
+interface HostReading {
+  branch: string
+  rulesetRules: Rule[]
+  classicStatus: 'configured' | 'not-configured' | 'forbidden'
+}
+
+function readHost(slug: string, branch: string): HostReading {
+  const rules = (gh(`repos/${slug}/rules/branches/${branch}`) as Rule[] | null) ?? [];
+  const code = ghExitCode(`repos/${slug}/branches/${branch}/protection`);
+  const classicStatus = code === 0 ? 'configured' : code === 1 ? 'not-configured' : 'forbidden';
+  return { branch, rulesetRules: rules, classicStatus };
+}
+
+function verify(gs: GitStrategy, slug: string, stamp: boolean): number {
+  const branches = protectedBranches(gs);
+  const codeowners = hasCodeowners();
+  const findings: Finding[] = [];
+
+  console.log(pc.bold('\nGit Policy Parity Report'));
+  console.log('='.repeat(50));
+  console.log(`Repository:  ${slug}`);
+  console.log(`Strategy:    ${gs.strategy}`);
+  console.log(`Protected:   ${branches.join(', ')}`);
+  console.log(`CODEOWNERS:  ${codeowners ? 'present' : 'absent'}`);
+  console.log('');
+
+  for (const branch of branches) {
+    const host = readHost(slug, branch);
+    const pr = host.rulesetRules.find(r => r.type === 'pull_request');
+    const p = (pr?.parameters ?? {}) as Partial<PullRequestParams>;
+
+    console.log(pc.bold(`Branch ${branch}`));
+    if (host.rulesetRules.length === 0) {
+      console.log('  no ruleset rules apply');
+    }
+    else {
+      console.log(`  rules: ${host.rulesetRules.map(r => r.type).join(', ')}`);
+    }
+    if (host.classicStatus === 'configured') {
+      console.log(`  ${pc.yellow('classic branch protection ALSO configured')} — two mechanisms union on this branch`);
+    }
+
+    // --- direct push ---
+    const declaredPush = gs.policy?.direct_push_to_protected ?? 'confirm';
+    const enforcedBlocked = pr !== undefined;
+    if (declaredPush === 'allowed' && enforcedBlocked) {
+      findings.push({
+        severity: 'drift',
+        field: `${branch}.direct_push_to_protected`,
+        declared: 'allowed',
+        enforced: 'blocked (a pull_request rule covers this branch)',
+        note: 'Bypass actors still get through; everyone else does not.',
+      });
+    }
+    if (declaredPush !== 'allowed' && !enforcedBlocked) {
+      findings.push({
+        severity: 'drift',
+        field: `${branch}.direct_push_to_protected`,
+        declared: declaredPush,
+        enforced: 'open (no pull_request rule)',
+      });
+    }
+
+    // --- reviews ---
+    const declaredReviews = gs.policy?.require_pr_reviews;
+    const enforcedReviews = pr ? (p.required_approving_review_count ?? 0) : null;
+    if (declaredReviews !== null && declaredReviews !== undefined && enforcedReviews !== null && declaredReviews !== enforcedReviews) {
+      findings.push({
+        severity: 'drift',
+        field: `${branch}.require_pr_reviews`,
+        declared: String(declaredReviews),
+        enforced: String(enforcedReviews),
+      });
+    }
+
+    // --- code owner review, the unsatisfiable-requirement trap ---
+    if (p.require_code_owner_review === true && !codeowners) {
+      findings.push({
+        severity: 'drift',
+        field: `${branch}.require_code_owner_review`,
+        declared: 'n/a (derived from CODEOWNERS, which is absent)',
+        enforced: 'true',
+        note: 'No CODEOWNERS file exists, so nobody outside the bypass list can ever satisfy this. Either add the file or turn the flag off.',
+      });
+    }
+
+    // --- merge methods ---
+    const wantMethods = allowedMergeMethods(gs);
+    const gotMethods = p.allowed_merge_methods;
+    if (pr && gotMethods && wantMethods) {
+      const same = wantMethods.length === gotMethods.length && wantMethods.every(m => gotMethods.includes(m));
+      if (!same) {
+        findings.push({
+          severity: 'drift',
+          field: `${branch}.allowed_merge_methods`,
+          declared: `${wantMethods.join(', ')} (from feature_merge: ${gs.decisions.feature_merge})`,
+          enforced: gotMethods.join(', '),
+        });
+      }
+    }
+
+    // --- force-push / deletion guards ---
+    for (const t of ['non_fast_forward', 'deletion'] as const) {
+      if (!host.rulesetRules.some(r => r.type === t)) {
+        findings.push({
+          severity: 'info',
+          field: `${branch}.${t}`,
+          declared: 'expected (every strategy protects against this)',
+          enforced: 'absent',
+        });
+      }
+    }
+    console.log('');
+  }
+
+  // --- admin bypass ---
+  const rs = (gh(`repos/${slug}/rulesets`) as { id: number, name: string }[] | null) ?? [];
+  const target = rs.find(r => r.name === RULESET_NAME) ?? rs[0];
+  if (target) {
+    const full = gh(`repos/${slug}/rulesets/${target.id}`) as { bypass_actors?: { actor_type: string, bypass_mode: string }[] } | null;
+    const actors = full?.bypass_actors ?? [];
+    const declaredBypass = gs.policy?.admin_bypass === true;
+    const hasAdminBypass = actors.some(a => a.actor_type === 'OrganizationAdmin' || a.actor_type === 'RepositoryRole');
+    console.log(pc.bold(`Ruleset ${target.name} (id ${target.id})`));
+    console.log(`  bypass_actors: ${actors.length === 0 ? 'none' : actors.map(a => `${a.actor_type}/${a.bypass_mode}`).join(', ')}`);
+    if (declaredBypass !== hasAdminBypass) {
+      findings.push({
+        severity: 'drift',
+        field: 'admin_bypass',
+        declared: String(declaredBypass),
+        enforced: String(hasAdminBypass),
+      });
+    }
+    console.log('');
+  }
+
+  // --- report ---
+  const drifts = findings.filter(f => f.severity === 'drift');
+  const infos = findings.filter(f => f.severity === 'info');
+
+  console.log(pc.bold(`DRIFT (${drifts.length}):`));
+  if (drifts.length === 0) { console.log('  <none>'); }
+  for (const f of drifts) {
+    console.log(`  ${pc.red('✖')} ${f.field}`);
+    console.log(`      declared: ${f.declared}`);
+    console.log(`      enforced: ${f.enforced}`);
+    if (f.note) { console.log(pc.dim(`      ${f.note}`)); }
+  }
+  if (infos.length > 0) {
+    console.log(`\n${pc.bold(`NOTES (${infos.length}):`)}`);
+    for (const f of infos) { console.log(`  ${pc.yellow('▲')} ${f.field}: ${f.enforced}`); }
+  }
+
+  console.log('');
+  if (drifts.length > 0) {
+    log.warn('Declared policy does not match the host.');
+    log.dim('Fix the host:  bun run git:policy apply --yes');
+    log.dim('Fix the yaml:  edit .agents/project.yaml -> git_strategy.policy, then re-run verify');
+    log.dim('Accept it:     record WHY in this project\'s CLAUDE.md -> ## Git Strategy');
+    return 1;
+  }
+
+  log.ok('Declared policy matches the host.');
+  if (stamp) { stampVerified(); }
+  else { log.dim('Re-run with --stamp to record meta.policy_verified / policy_source: verified'); }
+  return 0;
+}
+
+/** Append-only edit of the two meta fields. Never rewrites anything else. */
+function stampVerified(): void {
+  const today = new Date().toISOString().slice(0, 10);
+  const verifiedRe = /^(\s*)policy_verified:\s*\S+/m;
+  const sourceRe = /^(\s*)policy_source:\s*\S+/m;
+  let text = readFileSync(PROJECT_YAML, 'utf8');
+
+  // Absent fields and already-correct fields both produce an unchanged file, so
+  // test for presence FIRST. Reporting "could not stamp" on an already-stamped
+  // file trains the reader to ignore the warning.
+  if (!verifiedRe.test(text) || !sourceRe.test(text)) {
+    log.warn('meta.policy_verified / meta.policy_source not found in git_strategy.meta — nothing stamped.');
+    return;
+  }
+
+  const before = text;
+  text = text.replace(verifiedRe, `$1policy_verified: ${today}`);
+  text = text.replace(sourceRe, '$1policy_source: verified');
+  if (text === before) {
+    log.ok(`Already stamped: policy_verified: ${today}, policy_source: verified`);
+    return;
+  }
+  writeFileSync(PROJECT_YAML, text);
+  log.ok(`Stamped meta.policy_verified: ${today}, meta.policy_source: verified`);
+}
+
+// ---------------------------------------------------------------------------
+// apply
+// ---------------------------------------------------------------------------
+
+/**
+ * A change LOOSENS protection when it removes a guard or lowers the review bar.
+ * `apply` refuses those by default: a tool that can silently open `main` is a
+ * worse problem than the drift it fixes.
+ */
+function detectLoosening(current: Rule[], next: Rule[], slug: string, branch: string): string[] {
+  const out: string[] = [];
+  for (const t of ['deletion', 'non_fast_forward', 'required_signatures'] as const) {
+    if (current.some(r => r.type === t) && !next.some(r => r.type === t)) {
+      out.push(`${branch}: removes the \`${t}\` guard`);
+    }
+  }
+  const curPr = current.find(r => r.type === 'pull_request');
+  const nextPr = next.find(r => r.type === 'pull_request');
+  if (curPr && !nextPr) { out.push(`${branch}: removes the pull-request requirement entirely (direct pushes become possible)`); }
+  if (curPr && nextPr) {
+    const c = (curPr.parameters ?? {}) as Partial<PullRequestParams>;
+    const n = (nextPr.parameters ?? {}) as Partial<PullRequestParams>;
+    const cr = c.required_approving_review_count ?? 0;
+    const nr = n.required_approving_review_count ?? 0;
+    if (nr < cr) { out.push(`${branch}: lowers required approvals ${cr} -> ${nr}`); }
+    if (c.require_code_owner_review && !n.require_code_owner_review) {
+      out.push(`${branch}: turns off require_code_owner_review`);
+    }
+    const cm = c.allowed_merge_methods ?? [];
+    const nm = n.allowed_merge_methods ?? [];
+    const widened = nm.filter(m => cm.length > 0 && !cm.includes(m));
+    if (widened.length > 0) {
+      out.push(`${branch}: permits merge method(s) the host currently forbids: ${widened.join(', ')}`);
+    }
+  }
+  void slug;
+  return out;
+}
+
+function apply(gs: GitStrategy, slug: string, write: boolean, allowLoosening: boolean): number {
+  const branches = protectedBranches(gs);
+  const codeowners = hasCodeowners();
+
+  const rs = (gh(`repos/${slug}/rulesets`) as { id: number, name: string }[] | null) ?? [];
+  const existing = rs.find(r => r.name === RULESET_NAME) ?? null;
+
+  // Seed from whatever the ruleset already holds so unmanaged rules survive.
+  const currentRuleset = existing
+    ? (gh(`repos/${slug}/rulesets/${existing.id}`) as { rules?: Rule[] } | null)
+    : null;
+  const nextRules = buildRules(gs, codeowners, currentRuleset?.rules ?? []);
+
+  console.log(pc.bold('\nGit Policy Apply'));
+  console.log('='.repeat(50));
+  console.log(`Repository:  ${slug}`);
+  console.log(`Strategy:    ${gs.strategy}`);
+  console.log(`Ruleset:     ${existing ? `${RULESET_NAME} (id ${existing.id}) — UPDATE` : `${RULESET_NAME} — CREATE`}`);
+  console.log(`Branches:    ${branches.join(', ')}`);
+  console.log(`CODEOWNERS:  ${codeowners ? 'present -> require_code_owner_review: true' : 'absent -> require_code_owner_review: false'}`);
+  console.log('');
+  console.log(pc.bold('Rules to write:'));
+  for (const r of nextRules) {
+    if (r.type === 'pull_request') {
+      const p = r.parameters as unknown as PullRequestParams;
+      console.log(`  pull_request  reviews=${p.required_approving_review_count} codeowner=${p.require_code_owner_review} methods=[${p.allowed_merge_methods.join(', ')}]`);
+    }
+    else { console.log(`  ${r.type}`); }
+  }
+  console.log('');
+
+  // Loosening check against every branch currently covered.
+  const loosenings: string[] = [];
+  for (const b of branches) {
+    const current = (gh(`repos/${slug}/rules/branches/${b}`) as Rule[] | null) ?? [];
+    loosenings.push(...detectLoosening(current, nextRules, slug, b));
+  }
+
+  if (loosenings.length > 0) {
+    log.warn('This would LOOSEN protection:');
+    for (const l of loosenings) { console.log(`    ${pc.red('-')} ${l}`); }
+    if (!allowLoosening) {
+      console.log('');
+      fail('Refusing to loosen protection. Re-run with --allow-loosening if this is intended.');
+    }
+    console.log(pc.dim('  --allow-loosening given; proceeding.'));
+    console.log('');
+  }
+
+  const body = {
+    name: RULESET_NAME,
+    target: 'branch',
+    enforcement: 'active',
+    conditions: { ref_name: { include: branches.map(b => `refs/heads/${b}`), exclude: [] } },
+    rules: nextRules,
+    // bypass_actors is intentionally omitted on PATCH so the host keeps whatever
+    // is configured. On CREATE, seed org-admin bypass only when policy asks for it.
+    ...(existing ? {} : { bypass_actors: gs.policy?.admin_bypass ? [{ actor_type: 'OrganizationAdmin', bypass_mode: 'always' }] : [] }),
+  };
+
+  if (!write) {
+    console.log(pc.bold('Payload (dry run — nothing sent):'));
+    console.log(JSON.stringify(body, null, 2));
+    console.log('');
+    log.info('Dry run. Re-run with --yes to write it.');
+    return 0;
+  }
+
+  const tmp = join('/tmp', `git-policy-${process.pid}.json`);
+  writeFileSync(tmp, JSON.stringify(body));
+  const path = existing ? `repos/${slug}/rulesets/${existing.id}` : `repos/${slug}/rulesets`;
+  // GitHub's "Update a repository ruleset" is PUT, not PATCH — PATCH returns 404.
+  const method = existing ? 'PUT' : 'POST';
+  const p = Bun.spawnSync(['gh', 'api', '-X', method, path, '--input', tmp], { stdout: 'pipe', stderr: 'pipe' });
+  if (p.exitCode !== 0) {
+    log.err(`${method} ${path} failed:`);
+    console.log(p.stderr.toString().trim());
+    return 1;
+  }
+  log.ok(`${method} ${path} succeeded.`);
+  log.dim('Re-run `bun run git:policy verify --stamp` to record the reconciliation.');
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+const HELP = `
+git-policy — parity between .agents/project.yaml -> git_strategy and the host ruleset
+
+USAGE
+  bun run git:policy <command> [flags]
+
+COMMANDS
+  verify              Read the host, diff against git_strategy, report. Exit 1 on drift.
+  apply               Write the ruleset git_strategy implies. Dry-run unless --yes.
+  plan                Print the implied ruleset. No host calls.
+
+FLAGS
+  --stamp             (verify) write meta.policy_verified / policy_source when in parity
+  --yes               (apply) actually write; without it, apply is a dry run
+  --allow-loosening   (apply) permit a change that removes a guard or lowers the review bar
+  --help              this text
+
+NOTES
+  Rulesets only. Classic branch protection is READ by verify (a 404 there means
+  "not configured through that mechanism", never "unprotected") and never written.
+  bypass_actors and CODEOWNERS are reported, not managed — see the file header.
+`;
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h') || argv.length === 0) {
+    console.log(HELP);
+    process.exit(0);
+  }
+  const cmd = argv[0];
+  const gs = readStrategy();
+  const slug = readSlug();
+
+  switch (cmd) {
+    case 'verify':
+      process.exit(verify(gs, slug, argv.includes('--stamp')));
+      break;
+    case 'apply':
+      process.exit(apply(gs, slug, argv.includes('--yes'), argv.includes('--allow-loosening')));
+      break;
+    case 'plan': {
+      // `plan` makes no host calls, so it cannot know which unmanaged rules
+      // exist; it shows only what the strategy itself implies.
+      const rules = buildRules(gs, hasCodeowners());
+      console.log(JSON.stringify({
+        strategy: gs.strategy,
+        branches: protectedBranches(gs),
+        codeowners: hasCodeowners(),
+        rules,
+      }, null, 2));
+      process.exit(0);
+      break;
+    }
+    default:
+      fail(`Unknown command: ${cmd}. Use --help.`);
+  }
+}
+
+main();


### PR DESCRIPTION
Ports the branch-protection parity tooling from [`agentic-dev-boilerplate#13`](https://github.com/upex-galaxy/agentic-dev-boilerplate/pull/13) and [`#16`](https://github.com/upex-galaxy/agentic-dev-boilerplate/pull/16).

This repo's `git-flow-master` is an **older fork** of the sibling's: it carries QA-specific references the other lacks (`pr-test-automation.md`, `sdet-integration-trunk.md`) and it never had a Step 1b at all. The two SKILL.md files differ by 218 lines. So this is a port, adapted on the way in, not a copy.

## What arrives

- **`scripts/git-policy.ts`** + `bun run git:policy` — `plan` / `verify` (read-only, exit 1 on drift) / `apply` (dry run until `--yes`).
- **`references/ruleset-parity.md`** — the mapping, the non-goals, the worked example.
- **A Step 1b** that invokes the tool rather than describing the queries.

## Adapted for this repo

**`sdet` added to the branch mapping, explicitly.** It protects the production branch only: the per-suite trunk is ephemeral (`branches.ephemeral_pattern`) and `integration` is `null`. Protecting it would put ruleset friction on exactly the intermediate merges the strategy exists to keep frictionless. Declared rather than left to fall through to the default, because "the default happened to be right" is not a decision.

**`meta.strategy_source: inherited | chosen`**, matching the sibling. `strategy:` ships `solo-main` and is never null, so it cannot record whether anyone chose it.

**`meta.policy_verified` / `policy_source`** — this block was missing both entirely, so the reconciliation stamp had nowhere to land.

## Host change

`require_code_owner_review` turned off on ruleset `16809531`. It was `true` with **no CODEOWNERS file anywhere**, which is unsatisfiable rather than strict: nobody outside the bypass list could ever clear it, so every merge had to bypass. Done surgically through `gh api`, not through `git:policy apply` — see below. `required_signatures`, the approval count and both bypass entries were preserved and re-read afterwards.

`require_pr_reviews` corrected `0` → `1` to match what the host actually asks.

## What was deliberately NOT changed

`direct_push_to_protected` stays **`allowed`**.

The strategy `description` in `.agents/project.yaml` already documents that direct pushes to `main` are the norm here under standing authorization, and that the `Bypassed rule violations` line is expected and harmless. Flipping the value to `confirm` would make every agent stop and ask on a flow that was explicitly authorized.

So `verify` still reports one drift, and `CLAUDE.md` now records it as an **accepted divergence** with the reasoning — the resolution Step 1b prescribes for exactly this case. Two consequences documented there:

- `meta.policy_source` stays `declared`. A `verified` stamp would claim the two sides agree; they do not.
- **`git:policy apply` must not be run on this repository.** With `direct_push_to_protected: allowed`, the tool derives a ruleset with *no* `pull_request` rule, so applying it would strip the requirement for every non-bypass actor. The loosening guard blocks it, and that guard is currently the only thing between this config and an open `main`.

## Also

`CLAUDE.md` claimed this repo ships `git_strategy.strategy: null`. It ships `solo-main`, and has for some time. Corrected.

## Verification

`types`, `lint`, `format`, `vars` 0/0, `skills` 14/14, `registry` — all clean. `git:policy verify` goes from 2 drifts to 1, and the remaining one is the documented, intended divergence.
