### PR TITLE
chore(installer): rename wokitoki user-level skill to mkd

### DIFF
--- a/cli/install.ts
+++ b/cli/install.ts
@@ -290,9 +290,10 @@ const USER_LEVEL_SKILLS: ReadonlyArray<CommunitySkill> = [
   { package: 'https://github.com/obra/superpowers', skill: 'brainstorming' },
   { package: 'https://github.com/lewislulu/html-ppt-skill', skill: 'html-ppt' },
   { package: 'https://bun.sh/docs', skill: 'bun' },
-  // Cross-project human-in-the-loop feedback CLI (`toki`): a blocking browser UI
-  // the AI drives mid-conversation to collect structured, anchored answers.
-  { package: 'https://github.com/upex-galaxy/agentic-user-skills', skill: 'wokitoki' },
+  // Cross-project decision-deck CLI (`mkd`, Make Decision): the AI writes a spec
+  // of items (decision / question / report / table) and the user answers in a
+  // browser deck, pasting the Result JSON back into the chat (non-blocking).
+  { package: 'https://github.com/upex-galaxy/agentic-user-skills', skill: 'mkd' },
 ];
 
 // Matches Claude Code ${VAR} and ${VAR:-default} placeholders in .mcp.json.


### PR DESCRIPTION
The [agentic-user-skills](https://github.com/upex-galaxy/agentic-user-skills) repo renamed `wokitoki` (`toki`) to **`mkd` (Make Decision)** — same capabilities (questions, report reactions, answerable tables) fused into a Catch-Up-style decision deck, with a non-blocking copy-JSON flow by default and a no-install run model (`bun <skill-dir>/cli/index.ts`).

This installer only needs the skill name swapped in `USER_LEVEL_SKILLS` (plus the entry comment).

**Merge after** upex-galaxy/agentic-user-skills#1 lands on main, so `bunx skills add --global … mkd` resolves.